### PR TITLE
Read and use ALFA channels when present. Fixes #4

### DIFF
--- a/Assets/Scripts/OpenTS2/Content/Interfaces/ITextureFactory.cs
+++ b/Assets/Scripts/OpenTS2/Content/Interfaces/ITextureFactory.cs
@@ -30,5 +30,13 @@ namespace OpenTS2.Content.Interfaces
         public abstract object CreatePNGTexture(byte[] source);
 
         public abstract object CreateJPGTexture(byte[] source);
+
+        /// <summary>
+        /// Constructs a JPG with a provided alpha channel.
+        /// </summary>
+        /// <param name="source">The bytes of the jpg file.</param>
+        /// <param name="alphaChannel">The transparency channel (one byte per pixel).</param>
+        /// <returns></returns>
+        public abstract object CreateJPGTextureWithAlphaChannel(byte[] source, byte[] alphaChannel);
     }
 }

--- a/Assets/Scripts/OpenTS2/Engine/Core/TextureFactory.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Core/TextureFactory.cs
@@ -25,129 +25,45 @@ namespace OpenTS2.Engine.Core
     /// </summary>
     public class TextureFactory : ITextureFactory
     {
+
         public override object CreateJPGTexture(byte[] source)
         {
             Texture2D tex2D = new Texture2D(1, 1);
             tex2D.LoadImage(source);
-            var alphaCheck = Encoding.UTF8.GetString(source, 24, 4);
-            
-            //HORRIBLE Temp hack.
-            var hasAlpha = alphaCheck == "ALFA";
-            if (hasAlpha)
-            {
-                var pixels = tex2D.GetPixels();
-                for(var i=0;i<pixels.Length;i++)
-                {
-                    var pixel = pixels[i];
-                    var thresh = 0.075f;
-                    if (pixel.r <= thresh && pixel.g <= thresh && pixel.b <= thresh)
-                    {
-                        pixels[i] = Color.clear;
-                    }
-                }
-                var alphaTex = new Texture2D(tex2D.width, tex2D.height, TextureFormat.RGBA32, true);
-                alphaTex.SetPixels(pixels);
-                alphaTex.Apply();
-                //this sucks a lot
-                #if REMOVE_STRAY_PIXELS
-                    RemoveStrayPixels(ref alphaTex);
-                #endif
-                return alphaTex;
-            }
-            // TODO - Figure out how the fuck jpg alpha works. Preferably on the IMG codec, not here.
-            /*
-            var alphaCheck = Encoding.UTF8.GetString(source, 24, 4);
-            if (alphaCheck == "ALFA")
-            {
-                var alphaTex = new Texture2D(fTex.width, fTex.height);
-                var io = IoBuffer.FromBytes(source);
-                io.Seek(SeekOrigin.Begin, 24 + 4);
-                var transparentPixels = new List<Tuple<byte, byte>>();
-                var donePixels = 0;
-                
-                var pixels = new List<Color>();
-                while (donePixels <= fTex.width*fTex.height)
-                {
-                    var len = io.ReadByte();
-                    var value = (float)io.ReadByte() / (float)byte.MaxValue;
-                    for (var i=0;i<len;i++)
-                        pixels.Add(new Color(value,value,value));
-                    donePixels += len;
-                }
-                var currentY = 0;
-                var currentX = 0;
-                for (var i=0;i<pixels.Count;i++)
-                {
-                    alphaTex.SetPixel(currentX, currentY, pixels[i]);
-                    currentX += 1;
-                    if (currentX > alphaTex.width)
-                    {
-                        currentX = 0;
-                        currentY += 1;
-                    }    
-                }
-                alphaTex.Apply();
-                return alphaTex;
-            }*/
             return tex2D;
         }
-        #if REMOVE_STRAY_PIXELS
-        void RemoveStrayPixels(ref Texture2D texture)
+
+        public override object CreateJPGTextureWithAlphaChannel(
+            byte[] source, byte[] alphaChannel)
         {
-            var minNeighbors = 7;
-            for(var i=0;i<texture.width;i++)
+            Texture2D tex2D = new Texture2D(1, 1);
+            tex2D.LoadImage(source);
+            Debug.Assert(tex2D.width * tex2D.height == alphaChannel.Length);
+
+            var pixels = tex2D.GetPixels();
+
+            // Unity flattens the pixels left-to-right bottom-to-top but the alpha channel
+            // is top-to-bottom left-to-right.
+            var alphaCounter = 0;
+            for (var i = tex2D.height - 1; i >= 0; i--)
             {
-                for(var n=0;n<texture.height;n++)
+                for (var j = 0; j < tex2D.width; j++)
                 {
-                    var neighs = GetNeighbors(texture, i, n, 0, 1);
-                    if (neighs < minNeighbors)
-                    {
-                        texture.SetPixel(i, n, Color.clear);
-                    }
+                    byte transparency = alphaChannel[alphaCounter];
+                    alphaCounter++;
+
+                    // Unity Color uses floats from 0 to 1, the alpha
+                    // channel is bytes from 0 to 0xff.
+                    pixels[(i * tex2D.height) + j].a = ((float) transparency) / 0xff;
                 }
             }
-            texture.Apply();
+
+            var alphaTex = new Texture2D(tex2D.width, tex2D.height, TextureFormat.RGBA32, true);
+            alphaTex.SetPixels(pixels);
+            alphaTex.Apply();
+
+            return alphaTex;
         }
-
-
-        int GetNeighbors(Texture2D texture, int x, int y, int currentLevel = 0, int maxLevels = 3)
-        {
-            var avoid = new List<Tuple<int, int>>();
-            return GetNeighbors(texture, x, y, ref avoid, currentLevel, maxLevels);
-        }
-
-        int GetNeighbors(Texture2D texture, int x, int y, ref List<Tuple<int, int>> avoid, int currentLevel = 0, int maxLevels = 3)
-        {
-            var neighbors = 0;
-            var thresh = 0.01f;
-            avoid.Add(new Tuple<int, int>(x, y));
-            for(var i=-1;i<=1;i++)
-            {
-                for(var n=-1;n<=1;n++)
-                {
-                    var curX = x + i;
-                    var curY = y + n;
-                    var tuple = new Tuple<int, int>(curX, curY);
-                    if (avoid.IndexOf(tuple) < 0 && curX >= 0 && curX < texture.width && curY >= 0 && curY < texture.height)
-                    {
-                        var color = texture.GetPixel(curX, curY);
-                        if (color.r > thresh && color.g > thresh && color.b > thresh)
-                        {
-                            neighbors += 1;
-                            //avoid.Add(new Tuple<int, int>(curX, curY));
-                            var nextLevel = currentLevel + 1;
-                            if (nextLevel <= maxLevels)
-                            {
-                                neighbors += GetNeighbors(texture, curX, curY, ref avoid, nextLevel, maxLevels);
-                            }
-                        }
-                    }
-                }
-            }
-            return neighbors;
-        }
-
-        #endif
 
         public override object CreatePNGTexture(byte[] source)
         {

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/IMGCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/IMGCodec.cs
@@ -13,6 +13,7 @@ using OpenTS2.Content;
 using OpenTS2.Common;
 using OpenTS2.Content.DBPF;
 using System.Text;
+using OpenTS2.Files.Formats.JPEGWithAlfaSegment;
 
 namespace OpenTS2.Files.Formats.DBPF
 {
@@ -57,7 +58,16 @@ namespace OpenTS2.Files.Formats.DBPF
                     return new TextureAsset(textureFactory.CreatePNGTexture(bytes));
 
                 case 2:
-                    return new TextureAsset(textureFactory.CreateJPGTexture(bytes));
+                    {
+                        byte[] alphaChannel = JpegFileWithAlfaSegment.GetTransparencyFromAlfaSegment(bytes);
+                        if (alphaChannel != null)
+                        {
+                            return new TextureAsset(
+                                textureFactory.CreateJPGTextureWithAlphaChannel(bytes, alphaChannel));
+                        }
+
+                        return new TextureAsset(textureFactory.CreateJPGTexture(bytes));
+                    }
             }
             return null;
         }

--- a/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f73eab50d202d904399116a3a365d68c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa/JpegFileWithAlfaSegment.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa/JpegFileWithAlfaSegment.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.JPEGWithAlfaSegment
+{
+    class JpegFileWithAlfaSegment
+    {
+
+        /// <summary>
+        /// Returns transparency values from the ALFA segment in the JPEG if present,
+        /// otherwise returns null.
+        /// </summary>
+        /// <param name="source">The raw bytes of the JPEG.</param>
+        /// <returns></returns>
+        public static byte[] GetTransparencyFromAlfaSegment(byte[] source)
+        {
+            using (BinaryReader binReader = new BinaryReader(new MemoryStream(source)))
+            {
+                // Consume the two magic Start-of-Image bytes
+                byte[] startOfImageMagic = binReader.ReadBytes(2);
+                Debug.Assert(startOfImageMagic[0] == 0xff);
+                Debug.Assert(startOfImageMagic[1] == 0xd8);
+
+                // Based off http://fileformats.archiveteam.org/wiki/JPEG#Format
+                // and https://en.wikipedia.org/wiki/JPEG_File_Interchange_Format#File_format_structure
+                while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+                {
+                    // Read the segment marker.
+                    byte sectionMarker1 = binReader.ReadByte();
+                    Debug.Assert(sectionMarker1 == 0xff);
+                    byte sectionMarker2 = binReader.ReadByte();
+                    // ALFA segments are encoded as part of JFIF APP0 markers and they need to
+                    // be at the start of the file, so once we get past APP0 segments just break
+                    // out of this loop.
+                    if (sectionMarker2 != 0xe0)
+                    {
+                        break;
+                    }
+
+                    // These segments have a size, we check if they are the ALFA segment
+                    // or skip them. Swap the order as BinaryReader is little-endian and
+                    // JFIF files use big-endian.
+                    ushort segmentSize = Endian.SwapUInt16(binReader.ReadUInt16());
+                    string segmentName = Encoding.UTF8.GetString(binReader.ReadBytes(4));
+                    if (segmentName == "ALFA")
+                    {
+                        return RunLengthDecodeAlfaSegment(binReader, segmentSize - 6);
+                    }
+                    // Not an ALFA segment, seek forward to the next.
+                    binReader.BaseStream.Seek(segmentSize - 4 - 2, SeekOrigin.Current);
+                }
+            }
+
+            return null;
+        }
+
+        private static byte[] RunLengthDecodeAlfaSegment(BinaryReader alfaContents, int size)
+        {
+            var alphaChannel = new List<byte>();
+
+            var currentPosition = alfaContents.BaseStream.Position;
+            while (alfaContents.BaseStream.Position != currentPosition + size)
+            {
+                sbyte rleByte = alfaContents.ReadSByte();
+                if (rleByte < 0)
+                {
+                    // The next transparency byte repeats ((-n) + 1) times
+                    var numRepeats = (-rleByte) + 1;
+                    byte transparency = alfaContents.ReadByte();
+                    for (var i = 0; i < numRepeats; i++)
+                    {
+                        alphaChannel.Add(transparency);
+                    }
+                }
+                else
+                {
+                    // There are n unique transparency bytes coming.
+                    var numRepeats = rleByte + 1;
+                    for (var i = 0; i < numRepeats; i++)
+                    {
+                        alphaChannel.Add(alfaContents.ReadByte());
+                    }
+                }
+            }
+
+            return alphaChannel.ToArray();
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa/JpegFileWithAlfaSegment.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/JPEGWithAlfa/JpegFileWithAlfaSegment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86fd7b318084be74b87ee956fb412fed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds logic to handle the run-length-encoding for the ALFA channel in the `IMGCodec` and adds a new file type under `Formats/` for handling the special jpeg files with these segments.

Tested with `UITest`:

![image](https://user-images.githubusercontent.com/773529/205426746-c4dad591-4f05-4d6c-a414-b43223923842.png)
