### PR TITLE
Add unit tests through unity test runner

### DIFF
--- a/Assets/Scripts/OpenTS2/ScriptsAssembly.asmdef
+++ b/Assets/Scripts/OpenTS2/ScriptsAssembly.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "ScriptsAssembly",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/OpenTS2/ScriptsAssembly.asmdef.meta
+++ b/Assets/Scripts/OpenTS2/ScriptsAssembly.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ca5a75d0b18b02945b57c873e6d0c86a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b37f47d7b25200d45b64331c3296a255
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/OpenTS2.meta
+++ b/Assets/Tests/OpenTS2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cbbfcbcd8a55f2b4797e66fcd4c1a420
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/OpenTS2/Common.meta
+++ b/Assets/Tests/OpenTS2/Common.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4bd6c79470a03474d992bdbfa2a4255e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/OpenTS2/Common/Utils.meta
+++ b/Assets/Tests/OpenTS2/Common/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6d5f89f960c501e4d81349a93b791e5b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/OpenTS2/Common/Utils/BitUtilsTest.cs
+++ b/Assets/Tests/OpenTS2/Common/Utils/BitUtilsTest.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+using OpenTS2.Common.Utils;
+
+
+public class BitUtilsTest
+{
+    [Test]
+    public void AllBitsSetReturnsTrueWithSimpleMask()
+    {
+        Assert.IsTrue(BitUtils.AllBitsSet(1, 1));
+    }
+
+    [Test]
+    public void AllBitSetReturnsFalseWithSimpleMask()
+    {
+        Assert.IsFalse(BitUtils.AllBitsSet(0, 1));
+    }
+}

--- a/Assets/Tests/OpenTS2/Common/Utils/BitUtilsTest.cs.meta
+++ b/Assets/Tests/OpenTS2/Common/Utils/BitUtilsTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bcae43ad4cc1e64d932d2b5b10fa495
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "ScriptsAssembly"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Tests/Tests.asmdef.meta
+++ b/Assets/Tests/Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: df7fa31a584484140a8de49d8558fa7c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ OpenTS2 is an Open-Source Reimplementation of The Sims 2, using the Unity game e
 ## Progress
 Currently resource management, asset loading and saving and other engine code is being worked on. There is no playable build yet.
 
-## Prerequisites
-* [Unity 2020.3.32f1](https://unity3d.com/get-unity/download/archive) - Can be found under "Unity 2020.x", you could also download the Unity Hub and install from there. Unity version is subject to change, please keep an eye on this!
-* [Visual Studio 2019](https://visualstudio.microsoft.com/vs/)
-* A copy of The Sims 2 Ultimate Collection
-
-## Setup
-You need to have a "config.json" file in the root folder that provides paths to your Sims 2 UC installation and user directories. Copy the "config.example.json" file and rename it to "config.json" to start off, and type in your own paths.
-
 ## Acknowledgements
 * [InvertedTomato.CRC](https://github.com/invertedtomato/crc)
 * [TGA Image Reader](https://www.codeproject.com/Articles/31702/NET-Targa-Image-Reader)
@@ -25,3 +17,28 @@ You need to have a "config.json" file in the root folder that provides paths to 
 
 ## License
 This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Development
+
+## Prerequisites
+* [Unity 2020.3.32f1](https://unity3d.com/get-unity/download/archive) - Can be found under "Unity 2020.x", you could also download the Unity Hub and install from there. Unity version is subject to change, please keep an eye on this!
+* [Visual Studio 2019](https://visualstudio.microsoft.com/vs/)
+* A copy of The Sims 2 Ultimate Collection
+
+## Setup
+You need to have a "config.json" file in the root folder that provides paths to your Sims 2 UC installation and user directories. Copy the "config.example.json" file and rename it to "config.json" to start off, and type in your own paths.
+
+## Project Structure
+
+We follow the layout of a normal Unity project except:
+
+* `Assets/Scripts/OpenTS2` - Contains the bulk of the C# code that deals with TS2 formats and files.
+* `Assets/Scripts/OpenTS2/Engine` - Unity *specific* code tends to live in here to keep it
+  separate from the language-independent code in the directory.
+* `Assets/Tests/OpenTS2/` - Unit tests following the same directory structure as the `Scripts` folder.
+
+## Testing
+
+We currently use the [Unity Test Runner](https://docs.unity3d.com/2017.4/Documentation/Manual/testing-editortestsrunner.html)
+for unit testing code. These tests can be run inside of unity through the test runner tab or if you use Rider as your C#
+editor, inside of it.


### PR DESCRIPTION
As per the unity guide, this requires creating an assembly that depends on the `nunit.framework.dll` reference. In order to allow this testing assembly to access the code under the OpenTS2 folder, we create a `ScriptsAssembly` assembly that the `Tests` assembly can depend on.

Unfortunately these tests can only be run through unity or the Rider IDE but unless we want to do a clean separation of all the Unity bits from the C# code this will likely be the easiest option.

If this looks good and we want to go with this for testing, I'll go ahead and add a github workflow so these tests run on CI.

## Tests running in Unity

![image](https://user-images.githubusercontent.com/773529/206318731-ac448edb-a4b2-4091-8bf5-90ef13155f5e.png)

## Tests in the Rider IDE

![image](https://user-images.githubusercontent.com/773529/206318772-6b225c4b-43e5-4e88-ad2c-ca120fe80527.png)
