### PR TITLE
Add CI to run unity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request, workflow_dispatch]
+  
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ./Library
+          key: Library
+      - uses: game-ci/unity-test-runner@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          checkName: Unity Test Results


### PR DESCRIPTION
This will run the tests on a github action for pull requests. You can see an example run here: https://github.com/ammaraskar/OpenTS2/actions/runs/3645531478/jobs/6155795438

You will need to add your unity license as a secret in the github repo. Instructions are here under the *Setting up License* section. Basically you need to make a branch with a workflow and manually trigger it, that gives you a file to upload to unity and then you can download your license and add it a secret to the repo.