### PR TITLE
Implement Scenegraph parsing

### DIFF
--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3364e4854e29418396f2f854ff86f8d5
+timeCreated: 1675109948

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a87b29c313b844c69998a584cb2f2e45
+timeCreated: 1675374322

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TagExtensionBlock.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TagExtensionBlock.cs
@@ -1,0 +1,28 @@
+﻿using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
+{
+    public class TagExtensionBlock : ScenegraphDataBlock
+    {
+        public const uint TYPE_ID = 0x9a809646;
+        public const string BLOCK_NAME = "cTagExtension";
+        public override string BlockName => BLOCK_NAME;
+
+        public string Tag { get; }
+
+        public TagExtensionBlock(PersistTypeInfo blockTypeInfo, string tag) :
+            base(blockTypeInfo) => (Tag) = (tag);
+    }
+
+    public class TagExtensionBlockReader : IScenegraphDataBlockReader<TagExtensionBlock>
+    {
+        public TagExtensionBlock Deserialize(IoBuffer reader, PersistTypeInfo blockTypeInfo)
+        {
+            var extensionBlockTypeInfo = PersistTypeInfo.Deserialize(reader);
+            Debug.Assert(extensionBlockTypeInfo.Name == "cExtension", "Block in cExtensionTag was not cExtension");
+            var tag = reader.ReadPascalString();
+            return new TagExtensionBlock(blockTypeInfo, tag);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TagExtensionBlock.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TagExtensionBlock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0322b262018348e48fee11a346ca78e7
+timeCreated: 1675374333

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/PersistTypeInfo.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/PersistTypeInfo.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using OpenTS2.Files.Utils;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph
+{
+    /// <summary>
+    /// A common prefix used in many areas of Scenegraph serialization/deserialization. 
+    /// </summary>
+    public readonly struct PersistTypeInfo
+    {
+        public string Name { get; }
+        public uint TypeId { get; }
+        public uint Version { get; }
+
+        public PersistTypeInfo(string name, uint typeId, uint version) =>
+            (Name, TypeId, Version) = (name, typeId, version);
+
+        public static PersistTypeInfo Deserialize(IoBuffer reader)
+        {
+            var name = reader.ReadVariableLengthPascalString();
+            var typeId = reader.ReadUInt32();
+            var version = reader.ReadUInt32();
+            return new PersistTypeInfo(name, typeId, version);
+        }
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.Write(Name);
+            writer.Write(TypeId);
+            writer.Write(Version);
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(TypeId)}: {TypeId:X}, {nameof(Version)}: {Version}, {nameof(Name)}: {Name}";
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/PersistTypeInfo.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/PersistTypeInfo.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f27abf77f88d4051b6598e786d304941
+timeCreated: 1675223337

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphDataBlock.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphDataBlock.cs
@@ -1,0 +1,35 @@
+﻿using OpenTS2.Files.Utils;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph
+{
+    public abstract class ScenegraphDataBlock
+    {
+        /// <summary>
+        /// The name of the data block as stored in the PersistTypeInfo header. This should be stored as a constant
+        /// property.
+        ///
+        /// For example:
+        /// <code>
+        /// public const string BLOCK_NAME = "cImageData";
+        /// public override string BlockName => BLOCK_NAME;
+        /// </code>
+        /// </summary>
+        public abstract string BlockName { get; }
+
+
+        /// <summary>
+        /// The type and version of this block.
+        /// </summary>
+        public PersistTypeInfo BlockTypeInfo { get; }
+        protected ScenegraphDataBlock(PersistTypeInfo blockTypeInfo) => (BlockTypeInfo) = (blockTypeInfo);
+    }
+
+    /// <summary>
+    /// Factory class to implement deserialization for Scenegraph data blocks.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IScenegraphDataBlockReader<out T> where T : ScenegraphDataBlock
+    {
+        public abstract T Deserialize(IoBuffer reader, PersistTypeInfo blockTypeInfo);
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphDataBlock.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphDataBlock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a11eaa6ec84d4549945bc67d68ce24a9
+timeCreated: 1675227281

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph
+{
+    /// <summary>
+    /// This is the base RCOL/Scenegraph Resource Collection.
+    /// </summary>
+    public class ScenegraphResourceCollection
+    {
+        /// <summary>
+        /// The list of data blocks contained in the resource collection.
+        /// </summary>
+        public List<ScenegraphDataBlock> Blocks { get; }
+
+        private ScenegraphResourceCollection()
+        {
+            Blocks = new List<ScenegraphDataBlock>();
+        }
+
+
+        private const uint ScenegraphHeader = 0xFFFF0001;
+
+        public static ScenegraphResourceCollection Deserialize(IoBuffer reader)
+        {
+            var collection = new ScenegraphResourceCollection();
+
+            var versionMark = reader.ReadUInt32();
+            if (versionMark != ScenegraphHeader)
+            {
+                throw new Exception("Scenegraph resource has invalid header: " + versionMark.ToString("X"));
+            }
+
+            var fileLinks = reader.ReadUInt32();
+            if (fileLinks != 0)
+            {
+                throw new NotImplementedException("Scenegraph links are not implemented yet");
+            }
+
+            var itemCount = reader.ReadUInt32();
+
+            var itemTypes = new uint[itemCount];
+            for (var i = 0; i < itemCount; i++)
+            {
+                itemTypes[i] = reader.ReadUInt32();
+            }
+
+            foreach (var itemType in itemTypes)
+            {
+                var typeInfo = PersistTypeInfo.Deserialize(reader);
+                Debug.Assert(typeInfo.TypeId == itemType, "Type info header does not match types list");
+
+                if (!BlockReaders.TryGetValue(itemType, out var factory))
+                {
+                    throw new NotImplementedException($"Unimplemented Scenegraph type {typeInfo.Name} ({itemType})");
+                }
+
+                var block = factory.Deserialize(reader, typeInfo);
+                Debug.Assert(block.BlockName == typeInfo.Name,
+                    "Deserialized block's type name does not match expected");
+                collection.Blocks.Add(block);
+            }
+
+            return collection;
+        }
+
+        // Used to create instances of ScenegraphDataBlock based on the type id.
+        private static readonly Dictionary<uint, IScenegraphDataBlockReader<ScenegraphDataBlock>> BlockReaders =
+            new Dictionary<uint, IScenegraphDataBlockReader<ScenegraphDataBlock>>()
+            {
+                { TagExtensionBlock.TYPE_ID, new TagExtensionBlockReader() }
+            };
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 71f7154fa6984864a10913aa726e94e4
+timeCreated: 1675225992

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph.meta
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d37a574c0396472aa12139b89651128a
+timeCreated: 1675377923

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/PeristTypeInfoTest.cs
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/PeristTypeInfoTest.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using NUnit.Framework;
+using OpenTS2.Files.Formats.DBPF.Scenegraph;
+using OpenTS2.Files.Utils;
+
+public class PeristTypeInfoTest
+{
+    [Test]
+    public void DeserializesFromKnownData()
+    {
+        var cImageDataTypeInfo = new byte[]
+        {
+            0x0A, 0x63, 0x49, 0x6D, 0x61, 0x67, 0x65, 0x44, 0x61, 0x74, 0x61, 0x6C, 0x27, 0x4A, 0x1C, 0x09, 0x00, 0x00,
+            0x00
+        };
+
+        var reader = new IoBuffer(new MemoryStream(cImageDataTypeInfo));
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+
+        var typeInfo = PersistTypeInfo.Deserialize(reader);
+        Assert.That(typeInfo.Name, Is.EqualTo("cImageData"));
+        Assert.That(typeInfo.TypeId, Is.EqualTo(0x1C4A276C));
+        Assert.That(typeInfo.Version, Is.EqualTo(9));
+    }
+
+    [Test]
+    public void TypeInfoRoundTripsSuccessfully()
+    {
+        var typeInfo = new PersistTypeInfo("cFakeNode", 0xbeef, 1);
+
+        var stream = new MemoryStream();
+        var writer = new BinaryWriter(stream);
+        typeInfo.Serialize(writer);
+
+        var reader = new IoBuffer(stream);
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+        reader.Seek(SeekOrigin.Begin, 0);
+
+        var deserializedTypeInfo = PersistTypeInfo.Deserialize(reader);
+        Assert.That(deserializedTypeInfo, Is.EqualTo(typeInfo));
+    }
+}

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/PeristTypeInfoTest.cs.meta
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/PeristTypeInfoTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 89442af724d645c78c752348014de204
+timeCreated: 1675379879

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollectionTest.cs
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollectionTest.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using OpenTS2.Files.Formats.DBPF.Scenegraph;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+using OpenTS2.Files.Utils;
+using AssertionException = UnityEngine.Assertions.AssertionException;
+
+public class ScenegraphResourceCollectionTest
+{
+    [Test]
+    public void DeserializationThrowsWhenHeaderIncorrect()
+    {
+        var wrongHeader = new byte[] { 0x00, 0x00, 0x00, 0x00 };
+        var reader = new IoBuffer(new MemoryStream(wrongHeader));
+
+        var e = Assert.Throws<Exception>(() =>
+        {
+            ScenegraphResourceCollection.Deserialize(reader);
+        });
+        Assert.That(e.Message, Does.Contain("Scenegraph resource has invalid header"));
+    }
+
+    [Test]
+    public void DeserializationThrowsWhenFileLinksPresent()
+    {
+        var writer = new BinaryWriter(new MemoryStream());
+        // Header.
+        writer.Write(0xFFFF0001);
+        // Number of file links.
+        writer.Write(1);
+        // Number of data blocks.
+        writer.Write(0);
+
+        var reader = new IoBuffer(writer.BaseStream);
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+        reader.Seek(SeekOrigin.Begin, 0);
+        
+        var e = Assert.Throws<NotImplementedException>(() =>
+        {
+            ScenegraphResourceCollection.Deserialize(reader);
+        });
+        Assert.That(e.Message, Does.Contain("Scenegraph links are not implemented yet"));
+    }
+
+    [Test]
+    public void DeserializationThrowsWhenTypeNotSupported()
+    {
+        var writer = new BinaryWriter(new MemoryStream());
+        // Header.
+        writer.Write(0xFFFF0001);
+        // Number of file links.
+        writer.Write(0);
+        // Number of data blocks.
+        writer.Write(1);
+        // Item types.
+        writer.Write(0xbeef);
+        // First item.
+        new PersistTypeInfo("cFakeNode", 0xbeef, 1).Serialize(writer);
+
+        var reader = new IoBuffer(writer.BaseStream);
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+        reader.Seek(SeekOrigin.Begin, 0);
+        
+        var e = Assert.Throws<NotImplementedException>(() =>
+        {
+            ScenegraphResourceCollection.Deserialize(reader);
+        });
+        Assert.That(e.Message, Does.Contain("Unimplemented Scenegraph type cFakeNode"));
+    }
+
+    [Test]
+    public void DeserializesSingleItemSuccessfully()
+    {
+        var writer = new BinaryWriter(new MemoryStream());
+        // Header.
+        writer.Write(0xFFFF0001);
+        // Number of file links.
+        writer.Write(0);
+        // Number of data blocks.
+        writer.Write(1);
+        // Item types.
+        writer.Write(TagExtensionBlock.TYPE_ID);
+        // First item.
+        new PersistTypeInfo(TagExtensionBlock.BLOCK_NAME, TagExtensionBlock.TYPE_ID, 3).Serialize(writer);
+        new PersistTypeInfo("cExtension", 0, 1).Serialize(writer);
+        writer.Write("testTag");
+        
+        var reader = new IoBuffer(writer.BaseStream);
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+        reader.Seek(SeekOrigin.Begin, 0);
+
+        var scenegraphCollection = ScenegraphResourceCollection.Deserialize(reader);
+        Assert.That(scenegraphCollection.Blocks.Count, Is.EqualTo(1));
+        
+        var block = scenegraphCollection.Blocks[0];
+        Assert.That(block, Is.TypeOf(typeof(TagExtensionBlock)));
+        Assert.That(block.BlockTypeInfo.Name, Is.EqualTo(TagExtensionBlock.BLOCK_NAME));
+        Assert.That(block.BlockTypeInfo.TypeId, Is.EqualTo(TagExtensionBlock.TYPE_ID));
+        Assert.That(block.BlockTypeInfo.Version, Is.EqualTo(3));
+
+        var extensionBlock = (TagExtensionBlock)block;
+        Assert.That(extensionBlock.Tag, Is.EqualTo("testTag"));
+    }
+
+    [Test]
+    public void DeserializesMultipleItemsSuccessfully()
+    {
+        var writer = new BinaryWriter(new MemoryStream());
+        // Header.
+        writer.Write(0xFFFF0001);
+        // Number of file links.
+        writer.Write(0);
+        // Number of data blocks.
+        writer.Write(2);
+        // Item types.
+        writer.Write(TagExtensionBlock.TYPE_ID);
+        writer.Write(TagExtensionBlock.TYPE_ID);
+        // First item.
+        new PersistTypeInfo(TagExtensionBlock.BLOCK_NAME, TagExtensionBlock.TYPE_ID, 3).Serialize(writer);
+        new PersistTypeInfo("cExtension", 0, 1).Serialize(writer);
+        writer.Write("testTag1");
+        // Second item.
+        new PersistTypeInfo(TagExtensionBlock.BLOCK_NAME, TagExtensionBlock.TYPE_ID, 3).Serialize(writer);
+        new PersistTypeInfo("cExtension", 0, 1).Serialize(writer);
+        writer.Write("testTag2");
+        
+        var reader = new IoBuffer(writer.BaseStream);
+        reader.ByteOrder = ByteOrder.LITTLE_ENDIAN;
+        reader.Seek(SeekOrigin.Begin, 0);
+
+        var scenegraphCollection = ScenegraphResourceCollection.Deserialize(reader);
+        Assert.That(scenegraphCollection.Blocks.Count, Is.EqualTo(2));
+        
+        Assert.That(scenegraphCollection.Blocks[0], Is.TypeOf(typeof(TagExtensionBlock)));
+        Assert.That(scenegraphCollection.Blocks[1], Is.TypeOf(typeof(TagExtensionBlock)));
+
+        var block1 = (TagExtensionBlock)scenegraphCollection.Blocks[0];
+        var block2 = (TagExtensionBlock)scenegraphCollection.Blocks[1];
+        Assert.That(block1.Tag, Is.EqualTo("testTag1"));
+        Assert.That(block2.Tag, Is.EqualTo("testTag2"));
+    }
+}

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollectionTest.cs.meta
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollectionTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2ff94c392dd04bd8871c6511d5da1c51
+timeCreated: 1675377939


### PR DESCRIPTION
This adds initial support for deserializing RCOL/Scenegraph Resource Collection files. I tried to lay out the API so it's easy enough to add new data block types but a system similar to the CodecRegistry might be nice, we'll see how it goes.

The only data block currently implemented is the simplest one I could find, `cTagExtension` but I will follow up to add the `cImageData` / texture loading that I have ready.

Links are presently not supported, will add support for those later down the line.