### PR TITLE
Start reading elements section of GMDC

### DIFF
--- a/Assets/Scripts/OpenTS2/Content/DBPF/Scenegraph/ScenegraphModelAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/Scenegraph/ScenegraphModelAsset.cs
@@ -1,4 +1,8 @@
-﻿using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block.GeometryData;
 using UnityEngine;
 
 namespace OpenTS2.Content.DBPF.Scenegraph
@@ -6,6 +10,12 @@ namespace OpenTS2.Content.DBPF.Scenegraph
     public class ScenegraphModelAsset : AbstractAsset
     {
         public Mesh StaticBoundMesh { get; }
+
+        /// <summary>
+        /// The different primitives or groups in the model. For example, a bed may have a "bedding" and a "frame"
+        /// mesh primitive.
+        /// </summary>
+        public Dictionary<String, Mesh> Primitives { get; } = new Dictionary<String, Mesh>();
 
         public ScenegraphModelAsset(GeometryDataContainerBlock geometryBlock)
         {
@@ -16,6 +26,57 @@ namespace OpenTS2.Content.DBPF.Scenegraph
             };
             StaticBoundMesh.SetVertices(geometryBlock.StaticBounds.Vertices);
             StaticBoundMesh.SetTriangles(geometryBlock.StaticBounds.Faces, 0);
+
+            // Initialize each primitive.
+            foreach (var primitive in geometryBlock.Primitives)
+            {
+                Primitives[primitive.Name] = InitializeMeshFromPrimitive(geometryBlock, primitive);
+            }
+        }
+
+        private Mesh InitializeMeshFromPrimitive(GeometryDataContainerBlock geometryBlock, MeshPrimitive primitive)
+        {
+            var mesh = new Mesh
+            {
+                name = geometryBlock.Resource.ResourceName + "_" + primitive.Name
+            };
+
+            var elements = geometryBlock.GetGeometryElementsForPrimitive(primitive);
+            var vertices = elements.OfType<VertexElement>().Single();
+
+            mesh.SetVertices(vertices.Data);
+            mesh.SetTriangles(primitive.Faces, 0);
+
+            foreach (var geometryElement in elements)
+            {
+                switch (geometryElement)
+                {
+                    case VertexElement _:
+                        // Handled before this loop.
+                        break;
+                    case NormalElement normals:
+                        mesh.SetNormals(normals.Data);
+                        break;
+                    case TangentElement tangentsElement:
+                        // Unity wants Vec4s for the tangents with the last component used to flip the binormal.
+                        var tangents = new Vector4[tangentsElement.Data.Length];
+                        for (var i = 0; i < tangentsElement.Data.Length; i++)
+                        {
+                            var tangent = tangentsElement.Data[i];
+                            tangents[i] = new Vector4(tangent.x, tangent.y, tangent.z, 1);
+                        }
+                        mesh.SetTangents(tangents);
+                        break;
+                    case UVMapElement uvMap:
+                        mesh.SetUVs(0, uvMap.Data);
+                        break;
+                    default:
+                        Debug.LogWarning($"Unknown geometry element type: {geometryElement.GetType()}");
+                        break;
+                }
+            }
+
+            return mesh;
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Engine/Tests/ScenegraphGMDCTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/ScenegraphGMDCTest.cs
@@ -13,6 +13,7 @@ public class ScenegraphGMDCTest : MonoBehaviour
     
     public string PackageToLoad = "TestAssets/Scenegraph/teapot_model.package";
     public string ModelName = "teapot_tslocator_gmdc";
+    public string PrimitiveToShow = "teapot";
     
     private void Start()
     {
@@ -24,7 +25,15 @@ public class ScenegraphGMDCTest : MonoBehaviour
             new ResourceKey(ModelName, 0x1C0532FA, TypeIDs.SCENEGRAPH_GMDC));
         
         Debug.Log($"scenegraphModel: {scenegraphModel.GlobalTGI}");
+        Debug.Log($"primitives: {string.Join(" ", scenegraphModel.Primitives.Keys)}");
 
-        GetComponent<MeshFilter>().mesh = scenegraphModel.StaticBoundMesh;
+        if (scenegraphModel.Primitives.ContainsKey(PrimitiveToShow))
+        {
+            GetComponent<MeshFilter>().mesh = scenegraphModel.Primitives[PrimitiveToShow];
+        }
+        else
+        {
+            GetComponent<MeshFilter>().mesh = scenegraphModel.StaticBoundMesh;
+        }
     }
 }

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f079945d5e2444ea85cc1d677e215a1b
+timeCreated: 1677629391

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData/GeometryElement.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData/GeometryElement.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using OpenTS2.Files.Formats.DBPF.Types;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block.GeometryData
+{
+    /* Element ids and their names as from the wiki and game.
+    ╔═════════════╦════════════════════════╦══════════════╗
+    ║ ID          ║ Wiki Name              ║ Game Name    ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x114113c3  ║ (EP4) VertexID         ║ vertexid     ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x114113cd  ║ (EP4) RegionMask       ║ seamvertexid ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x1c4afc56  ║ Blend Indices          ║              ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x3b83078b  ║ Normals List           ║ norm         ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x3bd70105  ║ Bone Weights           ║ weights      ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x5b830781  ║ Vertices               ║ pos          ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x5c4afc5c  ║ Blend Weights          ║              ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x5cf2cfe1  ║ Morph Vertex Deltas    ║ posdelta     ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x69d92b93  ║ Bump Map Normal Deltas ║ binorm       ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x7c4dee82  ║ Target Indices         ║              ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x89d92ba0  ║ Bump Map Normals       ║ tangent      ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0x9bb38afb  ║ Binormals              ║              ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xbb8307ab  ║ UV Coordinates         ║ tc           ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xcb6f3a6a  ║ Normal Morph Deltas    ║ normdelta    ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xcb7206a1  ║ Colour                 ║ uvdelta      ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xdb830795  ║ UV Coordinate Deltas   ║ col          ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xdcf2cfdc  ║ Morph Vertex Map       ║ targetidx    ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xeb720693  ║ Colour Deltas          ║ coldelta     ║
+    ╠═════════════╬════════════════════════╬══════════════╣
+    ║ 0xfbd70111  ║ Bone Assignments       ║ blendidx     ║
+    ╚═════════════╩════════════════════════╩══════════════╝ */
+    internal static class GeometryElementIds
+    {
+        public const uint Normals = 0x3b83078b;
+        public const uint Vertices = 0x5b830781;
+        public const uint Tangents = 0x89d92ba0;
+        public const uint UVMap = 0xbb8307ab;
+    }
+
+    /// <summary>
+    /// GeometryElements are basic containers of geometric data such as uv maps, vertex lists, normal vectors etc.
+    ///
+    /// These are stored separately so they can be reused in different groups of the same model. For example, a model
+    /// for a bed may have groups for the frame, bedding and shadow that use different sets of faces in the
+    /// VertexElement or share a UVMapElement.
+    /// </summary>
+    public abstract class GeometryElement
+    {
+        public static GeometryElement ReadElement(uint elementId, byte[] elementData)
+        {
+            return elementId switch
+            {
+                GeometryElementIds.Normals => new NormalElement(elementData),
+                GeometryElementIds.Vertices => new VertexElement(elementData),
+                GeometryElementIds.Tangents => new TangentElement(elementData),
+                GeometryElementIds.UVMap => new UVMapElement(elementData),
+                _ => throw new ArgumentException($"Unknown geometry element id {elementId:X}")
+            };
+        }
+    }
+
+    /// <summary>
+    /// A GeometryElement consisting of 3 float elements: used for vertices, normal maps etc.
+    /// </summary>
+    public abstract class Vec3Element : GeometryElement
+    {
+        public Vector3[] Data { get; }
+
+        protected Vec3Element(byte[] elementData)
+        {
+            int numElements = elementData.Length / (3 * sizeof(float));
+            Data = new Vector3[numElements];
+
+            Debug.Log($"elementData length: {elementData.Length}, numElements: {numElements}");
+
+            IoBuffer buffer = IoBuffer.FromBytes(elementData);
+            for (int i = 0; i < numElements; i++)
+            {
+                Data[i] = Vector3Serializer.Deserialize(buffer);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A GeometryElement consisting of 2 float elements: used for uv maps, uv deltas etc.
+    /// </summary>
+    public abstract class Vec2Element : GeometryElement
+    {
+        public Vector2[] Data { get; }
+
+        protected Vec2Element(byte[] elementData)
+        {
+            int numElements = elementData.Length / (2 * sizeof(float));
+            Data = new Vector2[numElements];
+
+            IoBuffer buffer = IoBuffer.FromBytes(elementData);
+            for (int i = 0; i < numElements; i++)
+            {
+                Data[i] = Vector2Serializer.Deserialize(buffer);
+            }
+        }
+    }
+
+    public class VertexElement : Vec3Element
+    {
+        public VertexElement(byte[] elementData) : base(elementData)
+        {
+        }
+    }
+
+    public class NormalElement : Vec3Element
+    {
+        public NormalElement(byte[] elementData) : base(elementData)
+        {
+        }
+    }
+
+    public class TangentElement : Vec3Element
+    {
+        public TangentElement(byte[] elementData) : base(elementData)
+        {
+        }
+    }
+
+    public class UVMapElement : Vec2Element
+    {
+        public UVMapElement(byte[] elementData) : base(elementData)
+        {
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData/GeometryElement.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryData/GeometryElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0cadbab38f554f31879d13e65ac93683
+timeCreated: 1677629406

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryDataContainerBlock.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/GeometryDataContainerBlock.cs
@@ -1,4 +1,6 @@
-﻿using OpenTS2.Files.Formats.DBPF.Scenegraph.Block.GeometryData;
+﻿using System.Collections.Generic;
+using System.Linq;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block.GeometryData;
 using OpenTS2.Files.Formats.DBPF.Types;
 using OpenTS2.Files.Utils;
 using UnityEngine;
@@ -11,6 +13,26 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
     public struct MeshGeometry
     {
         public Vector3[] Vertices;
+        public ushort[] Faces;
+    }
+
+    /// <summary>
+    /// "Linkages" on the wiki. This ties together a bunch of `GeometryElement`s together as a single component.
+    /// Primitives, known as "groups" on the wiki index into these components.
+    /// </summary>
+    public struct MeshComponent
+    {
+        public ushort[] GeometryElementIndices;
+    }
+
+    /// <summary>
+    /// Called "groups" on the wiki. These are named parts of the model that may be independent of one another such
+    /// as the bedding vs the frame of a bed model.
+    /// </summary>
+    public struct MeshPrimitive
+    {
+        public string Name;
+        public uint ComponentIndex;
         public ushort[] Faces;
     }
 
@@ -27,6 +49,9 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
         /// </summary>
         public GeometryElement[] Elements { get; }
 
+        public MeshComponent[] Components { get; }
+        public MeshPrimitive[] Primitives { get; }
+
         /// <summary>
         /// Static bounding mesh for the whole model. Only used when there are no joints/bones.
         /// </summary>
@@ -39,8 +64,15 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
 
         public GeometryDataContainerBlock(PersistTypeInfo blockTypeInfo,
             ScenegraphResource resource, GeometryElement[] elements,
+            MeshComponent[] components, MeshPrimitive[] primitives,
             MeshGeometry staticBounds, MeshGeometry[] bonesBounds) : base(blockTypeInfo)
-            => (Resource, Elements, StaticBounds, BonesBounds) = (resource, elements, staticBounds, bonesBounds);
+            => (Resource, Elements, Components, Primitives, StaticBounds, BonesBounds) = (resource, elements,
+                components, primitives, staticBounds, bonesBounds);
+
+        public List<GeometryElement> GetGeometryElementsForPrimitive(MeshPrimitive primitive)
+        {
+            return Components[primitive.ComponentIndex].GeometryElementIndices.Select(elementIndex => Elements[elementIndex]).ToList();
+        }
     }
 
     public class GeometryDataContainerBlockReader : IScenegraphDataBlockReader<GeometryDataContainerBlock>
@@ -50,15 +82,13 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
             var resource = ScenegraphResource.Deserialize(reader);
             var elements = ReadElementsSection(reader, blockTypeInfo);
 
-            // Read but ignore the data in the mesh components section for now.
-            ReadMeshComponentsSection(reader, blockTypeInfo);
-            // Read but ignore the data in the primitives section for now.
-            ReadPrimitivesSection(reader, blockTypeInfo);
+            var components = ReadMeshComponentsSection(reader, blockTypeInfo);
+            var primitives = ReadPrimitivesSection(reader, blockTypeInfo);
 
-            var geometry = ReadStaticBoundSection(reader, blockTypeInfo);
+            var staticBound = ReadStaticBoundSection(reader, blockTypeInfo);
             var bones = ReadBonesSection(reader, blockTypeInfo);
 
-            return new GeometryDataContainerBlock(blockTypeInfo, resource, elements, geometry, bones);
+            return new GeometryDataContainerBlock(blockTypeInfo, resource, elements, components, primitives, staticBound, bones);
         }
 
         private static ushort[] ReadIndices(IoBuffer reader, uint version)
@@ -103,9 +133,12 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
             return elements;
         }
 
-        private static void ReadMeshComponentsSection(IoBuffer reader, PersistTypeInfo blockTypeInfo)
+        // These are called mesh components in the game and linkages on the wiki. They tie together sets of elements
+        // from the geometry elements.
+        private static MeshComponent[] ReadMeshComponentsSection(IoBuffer reader, PersistTypeInfo blockTypeInfo)
         {
             var numberOfComponents = reader.ReadUInt32();
+            var components = new MeshComponent[numberOfComponents];
             Debug.Log($"numberOfMeshComponents: {numberOfComponents}");
             for (var i = 0; i < numberOfComponents; i++)
             {
@@ -118,30 +151,42 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
                 var positionClassIndices = ReadIndices(reader, blockTypeInfo.Version);
                 var surfaceClassIndices = ReadIndices(reader, blockTypeInfo.Version);
                 var materialClassIndices = ReadIndices(reader, blockTypeInfo.Version);
+
+                components[i] = new MeshComponent { GeometryElementIndices = eltArrayIndices };
             }
+
+            return components;
         }
 
-        private static void ReadPrimitivesSection(IoBuffer reader, PersistTypeInfo blockTypeInfo)
+        private static MeshPrimitive[] ReadPrimitivesSection(IoBuffer reader, PersistTypeInfo blockTypeInfo)
         {
             var numberOfPrimitives = reader.ReadUInt32();
+            var primitives = new MeshPrimitive[numberOfPrimitives];
+
             Debug.Log($"numberOfPrimitives: {numberOfPrimitives}");
             for (var i = 0; i < numberOfPrimitives; i++)
             {
                 reader.ReadUInt32();
-                reader.ReadUInt32();
+                var componentIndex = reader.ReadUInt32();
 
                 var primitiveName = reader.ReadVariableLengthPascalString();
                 Debug.Log($"primitive name: {primitiveName}");
 
-                ReadIndices(reader, blockTypeInfo.Version);
+                var faces = ReadIndices(reader, blockTypeInfo.Version);
 
                 // marked as opacity amount in simswiki
                 reader.ReadInt32();
 
-                if (blockTypeInfo.Version <= 1) continue;
+                if (blockTypeInfo.Version > 1)
+                {
+                    ReadIndices(reader, blockTypeInfo.Version);
+                }
 
-                ReadIndices(reader, blockTypeInfo.Version);
+                primitives[i] = new MeshPrimitive
+                    { Name = primitiveName, ComponentIndex = componentIndex, Faces = faces };
             }
+
+            return primitives;
         }
 
         private static MeshGeometry ReadGeometry(IoBuffer reader, uint version)

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Types/Vector2Serializer.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Types/Vector2Serializer.cs
@@ -1,0 +1,13 @@
+﻿using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF.Types
+{
+    public class Vector2Serializer
+    {
+        public static Vector2 Deserialize(IoBuffer reader)
+        {
+            return new Vector2(reader.ReadFloat(), reader.ReadFloat());
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Types/Vector2Serializer.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Types/Vector2Serializer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9b1be05a2c904c6faf0529e6f869192d
+timeCreated: 1689381094

--- a/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/Codecs/ScenegraphModelCodecTest.cs
+++ b/Assets/Tests/OpenTS2/Files/Formats/DBPF/Scenegraph/Codecs/ScenegraphModelCodecTest.cs
@@ -25,5 +25,13 @@
             // close approximation :)
             Assert.That(modelAsset.StaticBoundMesh.vertexCount, Is.EqualTo(3241));
             Assert.That(modelAsset.StaticBoundMesh.triangles.Length / 3, Is.EqualTo(6320));
+
+            // Make sure there's one primitive called `teapot`
+            Assert.That(modelAsset.Primitives.Count, Is.EqualTo(1));
+            Assert.That(modelAsset.Primitives.ContainsKey("teapot"), Is.True);
+
+            var teapotPrimitive = modelAsset.Primitives["teapot"];
+            Assert.That(teapotPrimitive.vertexCount, Is.EqualTo(13248));
+            Assert.That(teapotPrimitive.triangles.Length / 3, Is.EqualTo(6320));
         }
     }


### PR DESCRIPTION
This adds the basic code to load in geometry elements from the GMDC to see if the structure of this code looks right. I'll follow up with the parsers for the other types and then start loading them into unity `Mesh` objects in the `ScenegraphModelAsset`.