### PR TITLE
Read cTransformNode blocks as part of Scenegraph collections.

### DIFF
--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/ShapeRefNodeBlock.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/ShapeRefNodeBlock.cs
@@ -110,48 +110,21 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
     /// </summary>
     public class BoundedNode
     {
-        public TransformNode Transform { get; }
+        public TransformNodeBlock Transform { get; }
 
-        public BoundedNode(TransformNode transform) => (Transform) = (transform);
+        public BoundedNode(TransformNodeBlock transform) => (Transform) = (transform);
 
         public static BoundedNode Deserialize(IoBuffer reader)
         {
             var typeInfo = PersistTypeInfo.Deserialize(reader);
             Debug.Assert(typeInfo.Name == "cBoundedNode");
 
-            var transform = TransformNode.Deserialize(reader);
+            var transform = TransformNodeBlockReader.DeserializeWithoutTypeInfo(reader);
 
             // ignored boolean, always written as 0.
             var ignoredBool = reader.ReadByte();
 
             return new BoundedNode(transform);
-        }
-    }
-
-    /// <summary>
-    /// cTransformNode, contains transformation and rotation data for a node.
-    /// </summary>
-    public class TransformNode
-    {
-        public CompositionTreeNodeBlock CompositionTree { get; }
-        public Vector3 Transform { get; }
-        public Quaternion Rotation { get; }
-        public uint BoneId { get; }
-
-        public TransformNode(CompositionTreeNodeBlock tree, Vector3 transform, Quaternion rotation, uint boneId) =>
-            (CompositionTree, Transform, Rotation, BoneId) = (tree, transform, rotation, boneId);
-
-        public static TransformNode Deserialize(IoBuffer reader)
-        {
-            var typeInfo = PersistTypeInfo.Deserialize(reader);
-            Debug.Assert(typeInfo.Name == "cTransformNode");
-
-            var compositionTree = CompositionTreeNodeBlock.Deserialize(reader);
-
-            var transform = Vector3Serializer.Deserialize(reader);
-            var rotation = QuaterionSerialzier.Deserialize(reader);
-            var boneId = reader.ReadUInt32();
-            return new TransformNode(compositionTree, transform, rotation, boneId);
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TransformNodeBlock.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TransformNodeBlock.cs
@@ -1,0 +1,51 @@
+﻿using OpenTS2.Files.Formats.DBPF.Types;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF.Scenegraph.Block
+{
+    /// <summary>
+    /// cTransformNode, contains transformation and rotation data for a geometry node (linked by a bone id).
+    /// </summary>
+    public class TransformNodeBlock : ScenegraphDataBlock
+    {
+        public const uint TYPE_ID = 0x65246462;
+        public const string BLOCK_NAME = "cTransformNode";
+        public override string BlockName => BLOCK_NAME;
+
+        public CompositionTreeNodeBlock CompositionTree { get; }
+        public Vector3 Transform { get; }
+        public Quaternion Rotation { get; }
+        public uint BoneId { get; }
+
+        public TransformNodeBlock(PersistTypeInfo typeInfo, CompositionTreeNodeBlock tree, Vector3 transform,
+            Quaternion rotation, uint boneId) : base(typeInfo) =>
+            (CompositionTree, Transform, Rotation, BoneId) = (tree, transform, rotation, boneId);
+    }
+
+    public class TransformNodeBlockReader : IScenegraphDataBlockReader<TransformNodeBlock>
+    {
+        public TransformNodeBlock Deserialize(IoBuffer reader, PersistTypeInfo blockTypeInfo)
+        {
+            return DeserializeWithTypeInfo(reader, blockTypeInfo);
+        }
+
+        public static TransformNodeBlock DeserializeWithoutTypeInfo(IoBuffer reader)
+        {
+            var typeInfo = PersistTypeInfo.Deserialize(reader);
+            Debug.Assert(typeInfo.Name == "cTransformNode");
+
+            return DeserializeWithTypeInfo(reader, typeInfo);
+        }
+
+        private static TransformNodeBlock DeserializeWithTypeInfo(IoBuffer reader, PersistTypeInfo blockTypeInfo)
+        {
+            var compositionTree = CompositionTreeNodeBlock.Deserialize(reader);
+
+            var transform = Vector3Serializer.Deserialize(reader);
+            var rotation = QuaterionSerialzier.Deserialize(reader);
+            var boneId = reader.ReadUInt32();
+            return new TransformNodeBlock(blockTypeInfo, compositionTree, transform, rotation, boneId);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TransformNodeBlock.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/Block/TransformNodeBlock.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: db95222c84e84378aa35a88884527a6c
+timeCreated: 1690411033

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/Scenegraph/ScenegraphResourceCollection.cs
@@ -117,6 +117,7 @@ namespace OpenTS2.Files.Formats.DBPF.Scenegraph
                 { ResourceNodeBlock.TYPE_ID, new ResourceNodeBlockReader() },
                 { DataListExtensionBlock.TYPE_ID, new DataListExtensionBlockReader() },
                 { ShapeRefNodeBlock.TYPE_ID, new ShapeRefNodeBlockReader() },
+                { TransformNodeBlock.TYPE_ID, new TransformNodeBlockReader() },
             };
 
         private static ResourceKey ReadResourceKey(IoBuffer reader)


### PR DESCRIPTION
I assumed these cTransformNodes only existed as part of cResourceNode but it looks like they can come up by themselves. Adding this now allows all neighborhood decoration resources to be loaded.

Obligatory progress pic:
![image](https://github.com/LazyDuchess/OpenTS2/assets/773529/0d0d4e5f-4fdb-45a4-aefb-a040b260f868)
