### PR TITLE
Add gameobject to transform from sims2 space to unity

### DIFF
--- a/Assets/Scripts/OpenTS2/Scenes/NeighborhoodDecorations.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/NeighborhoodDecorations.cs
@@ -37,10 +37,9 @@ namespace OpenTS2.Scenes
                 var bridgeObject = model.CreateGameObjectForShape();
                 bridgeObject.transform.position = (bridge.Road.Position.Position + bridge.PositionOffset);
 
-                // TODO: this is a temporary hack to fix bridge orientation, there's something weird going on with one
-                // of our axes that we need to do this...
-                var eulerRotation = bridge.ModelOrientation.eulerAngles;
-                bridgeObject.transform.Rotate(eulerRotation.x, eulerRotation.y, -eulerRotation.z);
+                // TODO: put this in a helper MonoBehavior or something.
+                var simsRotation = bridgeObject.transform.Find("simsRotations");
+                simsRotation.localRotation = bridge.ModelOrientation;
 
                 // Parent to this component.
                 bridgeObject.transform.parent = transform;
@@ -62,7 +61,11 @@ namespace OpenTS2.Scenes
 
                 var decorationObject = model.CreateGameObjectForShape();
                 decorationObject.transform.position = decoration.Position.Position;
-                decorationObject.transform.Rotate(0, 0, -decoration.Rotation);
+
+                // TODO: put this in a helper MonoBehavior or something.
+                var simsRotation = decorationObject.transform.Find("simsRotations");
+                simsRotation.Rotate(0, 0, decoration.Rotation);
+
                 // Parent to this component.
                 decorationObject.transform.parent = transform;
             }


### PR DESCRIPTION
Previously we were using an ad-hoc system where we were rotating meshes to -90 on the x-axis and applying a -1 scale to them. This worked to show them properly but meant that because our coordinate system was flipped all rotations from the game had to be inverted from a right-hand system to a left-hand system.

This change introduces a simRotations object that all the meshes sit under that takes raw rotations from the game. The parent game object then converts these all at once into the unity space.

All rotations from the game should now be applied to this simRotations object, we should likely move this ScenegraphResourceAsset generated game object into a helper MonoBehavior to make this easier to use.

---

![image](https://github.com/LazyDuchess/OpenTS2/assets/773529/617f7e2f-35ac-40ae-ad08-9bc069dfffc6)

![image](https://github.com/LazyDuchess/OpenTS2/assets/773529/dc217045-92f8-416a-b66b-6da5e92fd742)

![image](https://github.com/LazyDuchess/OpenTS2/assets/773529/def702dd-32e1-42ec-b370-2e9811777b69)
