### PR TITLE
Initial implementation of lot architecture

### DIFF
--- a/Assets/Scenes/Tests/LotLoadingTest.unity
+++ b/Assets/Scenes/Tests/LotLoadingTest.unity
@@ -251,6 +251,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   NeighborhoodPrefix: N001
   LotID: 82
+  Floor: 1
+  Mode: 3
 --- !u!1 &2081008752
 GameObject:
   m_ObjectHideFlags: 0
@@ -291,7 +293,7 @@ Light:
     m_CustomResolution: -1
     m_Strength: 1
     m_Bias: 0.05
-    m_NormalBias: 0.4
+    m_NormalBias: 0
     m_NearPlane: 0.2
     m_CullingMatrixOverride:
       e00: 1

--- a/Assets/Scenes/Tests/LotLoadingTest.unity
+++ b/Assets/Scenes/Tests/LotLoadingTest.unity
@@ -250,7 +250,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   NeighborhoodPrefix: N001
-  LotID: 10
+  LotID: 82
 --- !u!1 &2081008752
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/OpenTS2/Content/CatalogManager.cs
+++ b/Assets/Scripts/OpenTS2/Content/CatalogManager.cs
@@ -1,0 +1,94 @@
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Formats.DBPF;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenTS2.Content
+{
+    public class CatalogManager
+    {
+        public static CatalogManager Get()
+        {
+            return s_instance;
+        }
+
+        static CatalogManager s_instance;
+        public List<CatalogObjectAsset> Objects
+        {
+            get
+            {
+                return _entryByGUID.Values.ToList();
+            }
+        }
+
+        public List<CatalogFenceAsset> Fences
+        {
+            get
+            {
+                return _fenceByGUID.Values.ToList();
+            }
+        }
+
+        Dictionary<uint, CatalogObjectAsset> _entryByGUID = new Dictionary<uint, CatalogObjectAsset>();
+        Dictionary<uint, CatalogFenceAsset> _fenceByGUID = new Dictionary<uint, CatalogFenceAsset>();
+        readonly ContentProvider _provider;
+
+        public CatalogManager(ContentProvider provider)
+        {
+            s_instance = this;
+            _provider = provider;
+        }
+
+        public void Initialize()
+        {
+            _entryByGUID = new Dictionary<uint, CatalogObjectAsset>();
+            _fenceByGUID = new Dictionary<uint, CatalogFenceAsset>();
+
+            var objectList = _provider.GetAssetsOfType<CatalogObjectAsset>(TypeIDs.CATALOG_OBJECT);
+            foreach (CatalogObjectAsset element in objectList)
+            {
+                RegisterObject(element);
+            }
+
+            var fenceList = _provider.GetAssetsOfType<CatalogFenceAsset>(TypeIDs.CATALOG_FENCE);
+            foreach (CatalogFenceAsset element in fenceList)
+            {
+                RegisterFence(element);
+            }
+        }
+
+        private void RegisterObject(CatalogObjectAsset catObj)
+        {
+            // TODO: Follow string set for localization.
+
+            _entryByGUID[catObj.Guid] = catObj;
+        }
+
+        public CatalogObjectAsset GetEntryById(uint guid)
+        {
+            if (_entryByGUID.TryGetValue(guid, out var obj))
+            {
+                return obj;
+            }
+
+            return null;
+        }
+
+        private void RegisterFence(CatalogFenceAsset catObj)
+        {
+            // TODO: Follow string set for localization.
+
+            _fenceByGUID[catObj.Guid] = catObj;
+        }
+
+        public CatalogFenceAsset GetFenceById(uint guid)
+        {
+            if (_fenceByGUID.TryGetValue(guid, out var obj))
+            {
+                return obj;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Content/CatalogManager.cs
+++ b/Assets/Scripts/OpenTS2/Content/CatalogManager.cs
@@ -31,6 +31,7 @@ namespace OpenTS2.Content
 
         Dictionary<uint, CatalogObjectAsset> _entryByGUID = new Dictionary<uint, CatalogObjectAsset>();
         Dictionary<uint, CatalogFenceAsset> _fenceByGUID = new Dictionary<uint, CatalogFenceAsset>();
+        Dictionary<uint, CatalogRoofAsset> _roofByGUID = new Dictionary<uint, CatalogRoofAsset>();
         readonly ContentProvider _provider;
 
         public CatalogManager(ContentProvider provider)
@@ -43,6 +44,7 @@ namespace OpenTS2.Content
         {
             _entryByGUID = new Dictionary<uint, CatalogObjectAsset>();
             _fenceByGUID = new Dictionary<uint, CatalogFenceAsset>();
+            _roofByGUID = new Dictionary<uint, CatalogRoofAsset>();
 
             var objectList = _provider.GetAssetsOfType<CatalogObjectAsset>(TypeIDs.CATALOG_OBJECT);
             foreach (CatalogObjectAsset element in objectList)
@@ -54,6 +56,12 @@ namespace OpenTS2.Content
             foreach (CatalogFenceAsset element in fenceList)
             {
                 RegisterFence(element);
+            }
+
+            var roofList = _provider.GetAssetsOfType<CatalogRoofAsset>(TypeIDs.CATALOG_ROOF);
+            foreach (CatalogRoofAsset element in roofList)
+            {
+                RegisterRoof(element);
             }
         }
 
@@ -84,6 +92,23 @@ namespace OpenTS2.Content
         public CatalogFenceAsset GetFenceById(uint guid)
         {
             if (_fenceByGUID.TryGetValue(guid, out var obj))
+            {
+                return obj;
+            }
+
+            return null;
+        }
+
+        private void RegisterRoof(CatalogRoofAsset catObj)
+        {
+            // TODO: Follow string set for localization.
+
+            _roofByGUID[catObj.Guid] = catObj;
+        }
+
+        public CatalogRoofAsset GetRoofById(uint guid)
+        {
+            if (_roofByGUID.TryGetValue(guid, out var obj))
             {
                 return obj;
             }

--- a/Assets/Scripts/OpenTS2/Content/CatalogManager.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/CatalogManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26295257e69bfd148bb5192d762ff021
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogFenceAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogFenceAsset.cs
@@ -1,0 +1,48 @@
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Content.DBPF
+{
+    public static class CatalogFenceType
+    {
+        public const string Fence = "fence";
+    }
+
+    public class CatalogFenceAsset : AbstractAsset
+    {
+        /// <summary>
+        /// Contents can vary based on type.
+        /// </summary>
+        public PropertySet Properties { get; }
+
+        /// <summary>
+        /// The global unique id for the object.
+        /// </summary>
+        public uint Guid { get; }
+
+        /// <summary>
+        /// Type of catalog object. See CatalogFenceType.
+        /// </summary>
+        public string Type => Properties.GetProperty<StringProp>("type").Value;
+
+        /// <summary>
+        /// Diagonal rail resource. (optional)
+        /// </summary>
+        public string DiagRail => Properties.Properties.TryGetValue("diagrail", out IPropertyType prop) ? ((StringProp)prop).Value : null;
+
+        /// <summary>
+        /// Rail resource.
+        /// </summary>
+        public string Rail => Properties.GetProperty<StringProp>("rail").Value;
+
+        /// <summary>
+        /// Post resource.
+        /// </summary>
+        public string Post => Properties.GetProperty<StringProp>("post").Value;
+
+        public CatalogFenceAsset(PropertySet propertySet)
+        {
+            Properties = propertySet;
+            Guid = propertySet.GetProperty<Uint32Prop>("guid").Value;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogFenceAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogFenceAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6c03a41333312c4a96d492bc476e718
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogObjectAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogObjectAsset.cs
@@ -1,0 +1,39 @@
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Content.DBPF
+{
+    public static class CatalogObjectType
+    {
+        public const string Floor = "floor";
+        public const string Wall = "wall";
+    }
+
+    public class CatalogObjectAsset : AbstractAsset
+    {
+        /// <summary>
+        /// Contents can vary based on type.
+        /// </summary>
+        public PropertySet Properties { get; }
+
+        /// <summary>
+        /// The global unique id for the object.
+        /// </summary>
+        public uint Guid { get; }
+
+        /// <summary>
+        /// Attached material for walls/floors.
+        /// </summary>
+        public string Material => Properties.GetProperty<StringProp>("material").Value;
+
+        /// <summary>
+        /// Type of catalog object. See CatalogObjectType.
+        /// </summary>
+        public string Type => Properties.GetProperty<StringProp>("type").Value;
+
+        public CatalogObjectAsset(PropertySet propertySet)
+        {
+            Properties = propertySet;
+            Guid = propertySet.GetProperty<Uint32Prop>("guid").Value;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogObjectAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogObjectAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adf33e8a5e9f5d644bcfed9fd8113dbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogRoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogRoofAsset.cs
@@ -1,0 +1,58 @@
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Content.DBPF
+{
+    public static class CatalogRoofType
+    {
+        public const string Roof = "roof";
+    }
+
+    public class CatalogRoofAsset : AbstractAsset
+    {
+        /// <summary>
+        /// Contents can vary based on type.
+        /// </summary>
+        public PropertySet Properties { get; }
+
+        /// <summary>
+        /// The global unique id for the object.
+        /// </summary>
+        public uint Guid { get; }
+
+        /// <summary>
+        /// Type of catalog object. See CatalogFenceType.
+        /// </summary>
+        public string Type => Properties.GetProperty<StringProp>("type").Value;
+
+        /// <summary>
+        /// Roof top bumpmap texture.
+        /// </summary>
+        public string TextureTopBump => Properties.Properties.TryGetValue("tecturetopbump", out IPropertyType prop) ? ((StringProp)prop).Value : null;
+
+        /// <summary>
+        /// Roof top texture.
+        /// </summary>
+        public string TextureTop => Properties.GetProperty<StringProp>("texturetop").Value;
+
+        /// <summary>
+        /// Roof edge texture.
+        /// </summary>
+        public string TextureEdges => Properties.GetProperty<StringProp>("textureedges").Value;
+
+        /// <summary>
+        /// Roof trim texture.
+        /// </summary>
+        public string TextureTrim => Properties.GetProperty<StringProp>("texturetrim").Value;
+
+        /// <summary>
+        /// Roof under texture.
+        /// </summary>
+        public string TextureUnder => Properties.GetProperty<StringProp>("textureunder").Value;
+
+        public CatalogRoofAsset(PropertySet propertySet)
+        {
+            Properties = propertySet;
+            Guid = propertySet.GetProperty<Uint32Prop>("guid").Value;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/CatalogRoofAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/CatalogRoofAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3287c1e837b7aa458d5b87ed4a3e2b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/FencePostLayerAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/FencePostLayerAsset.cs
@@ -1,0 +1,28 @@
+using OpenTS2.Scenes.Lot;
+
+namespace OpenTS2.Content.DBPF
+{
+    public struct FencePost
+    {
+        public int Level;
+        public float XPos;
+        public float YPos;
+        public uint GUID;
+
+        public override string ToString()
+        {
+            return $"({XPos}, {YPos}, {Level}): {GUID:x8}";
+        }
+    }
+
+    public class FencePostLayerAsset : AbstractAsset
+    {
+        public FencePost[] Entries { get; }
+
+        public FencePostLayerAsset(FencePost[] entries)
+        {
+            Entries = entries;
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/FencePostLayerAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/FencePostLayerAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06439e869b808ac429b43b0e0f5c0be1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/LotTexturesAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/LotTexturesAsset.cs
@@ -1,0 +1,26 @@
+namespace OpenTS2.Content.DBPF
+{
+    /// <summary>
+    /// Contains a collection of resource names for terrain textures.
+    /// </summary>
+    public class LotTexturesAsset : AbstractAsset
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public string BaseTexture { get; }
+        public string[] BlendTextures { get; }
+
+        public LotTexturesAsset(int width, int height, string baseTexture, string[] blendTextures)
+        {
+            Width = width;
+            Height = height;
+            BaseTexture = baseTexture;
+            BlendTextures = blendTextures;
+        }
+
+        public override string ToString()
+        {
+            return $"Lot Textures {TGI.InstanceID}: \n {BaseTexture}: {string.Join(", ", BlendTextures)}";
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/LotTexturesAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/LotTexturesAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b3c7ab3963ecbe4190f8325a6e68b93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs
@@ -1,0 +1,26 @@
+namespace OpenTS2.Content.DBPF
+{
+    public struct PoolEntry
+    {
+        public int Unknown1;
+        public float XPos;
+        public float YPos;
+        public int Level;
+        public int XSize;
+        public int YSize;
+        public int Unknown2;
+        public float YOffset;
+        public int Unknown3;
+    }
+
+    public class PoolAsset : AbstractAsset
+    {
+        public PoolEntry[] Entries { get; }
+
+        public PoolAsset(PoolEntry[] entries)
+        {
+            Entries = entries;
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs
@@ -2,7 +2,7 @@ namespace OpenTS2.Content.DBPF
 {
     public struct PoolEntry
     {
-        public int Unknown1;
+        public int Id;
         public float XPos;
         public float YPos;
         public int Level;

--- a/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/PoolAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24f85bd31fc188f46a2cde8cb0fb4282
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
@@ -8,15 +8,16 @@ namespace OpenTS2.Content.DBPF
         LongGable = 4,
         Hip = 5,
         Mansard = 6, // This becomes Hip if the roof is too small?
+
         Cone = 7,
         Dome = 8,
         Octogonal = 9,
 
-        // Diagonals next.
-
-        // DiagonalLongGable
-
-        // Then all the stupid ones
+        DiagonalLongGable = 10,
+        DiagonalShortGable = 11,
+        DiagonalHip = 12,
+        DiagonalShedGable = 13,
+        DiagonalShedHip = 14,
 
         // Straight roofs with the same slope support:
         // - Combined gabled edge that can make a jagged appearing line (cuts out lines that go under other roofs)

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
@@ -19,6 +19,13 @@ namespace OpenTS2.Content.DBPF
         DiagonalShedGable = 13,
         DiagonalShedHip = 14,
 
+        PagodaHip = 16,
+        PagodaLongGable = 17,
+        PagodaShedGable = 18,
+        DiagonalPagodaHip = 19,
+        DiagonalPagodaLongGable = 20,
+        DiagonalPagodaShedGable = 21
+
         // Straight roofs with the same slope support:
         // - Combined gabled edge that can make a jagged appearing line (cuts out lines that go under other roofs)
         //

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
@@ -1,0 +1,54 @@
+namespace OpenTS2.Content.DBPF
+{
+    public enum RoofType
+    {
+        ShedGabled = 1,
+        ShedHipped = 2,
+        ShortGable = 3,
+        LongGable = 4,
+        Hip = 5,
+        Mansard = 6
+
+        // DiagonalLongGable
+
+        // Then all the stupid ones
+
+        // Straight roofs with the same slope support:
+        // - Combined gabled edge that can make a jagged appearing line (cuts out lines that go under other roofs)
+        //
+        // Straight/diagonal roofs with the same slope support:
+        // - Pretty intersection edges (but not between diag and straight)
+        //
+        // All other roofs don't really interact with each other.
+    }
+
+    public struct RoofEntry
+    {
+        public int Id;
+        public float XFrom;
+        public float YFrom;
+        public int LevelFrom;
+        public float XTo;
+        public float YTo;
+        public int LevelTo;
+        public RoofType Type;
+        public int Pattern;
+
+        // Version 2
+        public float RoofAngle;
+
+        // Version 3
+        public int RoofStyleExtended;
+    }
+
+    public class RoofAsset : AbstractAsset
+    {
+        public RoofEntry[] Entries { get; }
+
+        public RoofAsset(RoofEntry[] entries)
+        {
+            Entries = entries;
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
@@ -19,20 +19,14 @@ namespace OpenTS2.Content.DBPF
         DiagonalShedGable = 13,
         DiagonalShedHip = 14,
 
+        GreenhouseLongGable = 15,
+
         PagodaHip = 16,
         PagodaLongGable = 17,
         PagodaShedGable = 18,
         DiagonalPagodaHip = 19,
         DiagonalPagodaLongGable = 20,
         DiagonalPagodaShedGable = 21
-
-        // Straight roofs with the same slope support:
-        // - Combined gabled edge that can make a jagged appearing line (cuts out lines that go under other roofs)
-        //
-        // Straight/diagonal roofs with the same slope support:
-        // - Pretty intersection edges (but not between diag and straight)
-        //
-        // All other roofs don't really interact with each other.
     }
 
     public struct RoofEntry

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs
@@ -7,7 +7,12 @@ namespace OpenTS2.Content.DBPF
         ShortGable = 3,
         LongGable = 4,
         Hip = 5,
-        Mansard = 6
+        Mansard = 6, // This becomes Hip if the roof is too small?
+        Cone = 7,
+        Dome = 8,
+        Octogonal = 9,
+
+        // Diagonals next.
 
         // DiagonalLongGable
 
@@ -32,7 +37,7 @@ namespace OpenTS2.Content.DBPF
         public float YTo;
         public int LevelTo;
         public RoofType Type;
-        public int Pattern;
+        public uint Pattern;
 
         // Version 2
         public float RoofAngle;

--- a/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/RoofAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b598320ddcb1d3469224abae4c9ebe4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/Scenegraph/ScenegraphMaterialDefinitionAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/Scenegraph/ScenegraphMaterialDefinitionAsset.cs
@@ -42,13 +42,13 @@ namespace OpenTS2.Content.DBPF.Scenegraph
             _material.Free();
         }
 
-        public Material GetAsUnityMaterial()
+        public Material GetAsUnityMaterial(string forceType = null)
         {
             if (_material != null)
             {
                 return _material;
             }
-            _material = MaterialManager.Parse(this);
+            _material = MaterialManager.Parse(this, forceType);
             return _material;
         }
     }

--- a/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace OpenTS2.Content.DBPF
+{
+    public struct StringMapEntry
+    {
+        public string Value;
+        public ushort Id;
+        public ushort Unknown1;
+        public ushort Unknown2;
+
+        public override string ToString()
+        {
+            return $"{Value}: {Id} ({Unknown1} {Unknown2})";
+        }
+    }
+
+    public class StringMapAsset : AbstractAsset
+    {
+        public Dictionary<ushort, StringMapEntry> Map { get; }
+
+        public StringMapAsset(StringMapEntry[] entries)
+        {
+            Map = new Dictionary<ushort, StringMapEntry>(entries.Length);
+
+            for (int i = 0; i < entries.Length; i++)
+            {
+                Map.Add(entries[i].Id, entries[i]);
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs
@@ -6,12 +6,11 @@ namespace OpenTS2.Content.DBPF
     {
         public string Value;
         public ushort Id;
-        public ushort Unknown1;
-        public ushort Unknown2;
+        public uint Unknown;
 
         public override string ToString()
         {
-            return $"{Value}: {Id} ({Unknown1} {Unknown2})";
+            return $"{Value}: {Id} ({Unknown})";
         }
     }
 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/StringMapAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97af1e63a0cab4e4dbee0302f72892b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/WallGraphAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/WallGraphAsset.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+
+namespace OpenTS2.Content.DBPF
+{
+    public struct WallGraphPositionEntry
+    {
+        public int Id;
+        public float XPos;
+        public float YPos;
+        public int Level;
+        public override string ToString()
+        {
+            return $"{Id}: ({XPos:x4}, {YPos:x4}, {Level})";
+        }
+    }
+
+    public struct WallGraphLineEntry
+    {
+        public int LayerId;
+        public int FromId;
+        public int Room1;
+        public int ToId;
+        public int Room2;
+        public override string ToString()
+        {
+            return $"{LayerId} ({FromId}->{ToId}): {Room1} {Room2}";
+        }
+    }
+
+    public class WallGraphAsset : AbstractAsset
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public int Floors { get; }
+        public int BaseFloor { get; }
+        public Dictionary<int, WallGraphPositionEntry> Positions { get; }
+        public int[] Rooms { get; }
+        public WallGraphLineEntry[] Lines { get; }
+
+        public WallGraphAsset(int width, int height, int floors, int baseFloor, WallGraphPositionEntry[] pos, int[] rooms, WallGraphLineEntry[] lines)
+        {
+            Width = width;
+            Height = height;
+            Floors = floors;
+            BaseFloor = baseFloor;
+            Positions = ToPositionDictionary(pos);
+            Rooms = rooms;
+            Lines = lines;
+        }
+
+        private Dictionary<int, WallGraphPositionEntry> ToPositionDictionary(WallGraphPositionEntry[] pos)
+        {
+            var result = new Dictionary<int, WallGraphPositionEntry>(pos.Length);
+
+            foreach (var position in pos)
+            {
+                result[position.Id] = position;
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/WallGraphAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/WallGraphAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac47da21942bb34428895592efc7b581
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs
@@ -2,10 +2,25 @@ using System.Collections.Generic;
 
 namespace OpenTS2.Content.DBPF
 {
+    public enum WallType : int
+    {
+        Normal = 1,
+        ThinFence = 2, // unused?
+        Roof = 3,
+        DeckInvis = 4,
+        Deck = 16,
+        Foundation = 23,
+        Deck2 = 24,
+        Deck3 = 26,
+        Pool = 29,
+        OFBWall = 300,
+        OFBScreen = 301
+    }
+
     public struct WallLayerEntry
     {
         public int Id;
-        public int WallType; // 1/3?
+        public WallType WallType;
         public ushort Pattern1;
         public ushort Pattern2;
 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace OpenTS2.Content.DBPF
+{
+    public struct WallLayerEntry
+    {
+        public int Id;
+        public int WallType; // 1/3?
+        public ushort Pattern1;
+        public ushort Pattern2;
+
+        public override string ToString()
+        {
+            return $"{Id}: {WallType} w/ patterns: {Pattern1} {Pattern2}";
+        }
+    }
+
+    public class WallLayerAsset : AbstractAsset
+    {
+        public Dictionary<int, WallLayerEntry> Walls { get; }
+
+        public WallLayerAsset(WallLayerEntry[] walls)
+        {
+            Walls = ToLayerDictionary(walls);
+        }
+
+        private Dictionary<int, WallLayerEntry> ToLayerDictionary(WallLayerEntry[] pos)
+        {
+            var result = new Dictionary<int, WallLayerEntry>(pos.Length);
+
+            foreach (var position in pos)
+            {
+                result[position.Id] = position;
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/WallLayerAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d31d7ced2c562fd4f8fbd50aac592b1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs
@@ -1,54 +1,117 @@
+using OpenTS2.Files.Utils;
 using System;
-using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace OpenTS2.Content.DBPF
 {
-    public interface IArrayAsset
+    public interface IArrayView
     {
+        void Update();
+        void Commit();
         Type ArrayType();
+    }
+
+    /// <summary>
+    /// A typed view into a 2D array.
+    /// This is essentially a copy of the base data. It should be committed to save back to the parent array.
+    /// </summary>
+    /// <typeparam name="T">Array element type</typeparam>
+    public class _2DArrayView<T> : IArrayView where T : unmanaged
+    {
+        public _2DArrayAsset Parent { get; }
+        public int Width { get; }
+        public int Height { get; }
+        public T[] Data { get; }
+
+        public _2DArrayView(_2DArrayAsset asset)
+        {
+            if (UnsafeUtility.SizeOf<T>() != asset.ElementSize)
+            {
+                throw new InvalidOperationException($"2D array view made of type {typeof(T).Name} with expected element size {UnsafeUtility.SizeOf<T>()}, but source data is for element size {asset.ElementSize}.");
+            }
+
+            Parent = asset;
+            Width = asset.Width;
+            Height = asset.Height;
+            Data = new T[Width * Height];
+
+            Update();
+        }
+
+        /// <summary>
+        /// Take values from the parent 2D array.
+        /// </summary>
+        public void Update()
+        {
+            ReinterpretCast.Copy(Parent.Data, Data, Data.Length * Parent.ElementSize);
+        }
+
+        /// <summary>
+        /// Commit changes back to the parent 2D array.
+        /// </summary>
+        public void Commit()
+        {
+            ReinterpretCast.Copy(Data, Parent.Data, Data.Length * Parent.ElementSize);
+        }
+
+        /// <summary>
+        /// Get the type of the array view.
+        /// </summary>
+        /// <returns>The array view type</returns>
+        public Type ArrayType()
+        {
+            return typeof(T);
+        }
     }
 
     /// <summary>
     /// Contains a 2D Array of data.
     /// </summary>
-    public class _2DArrayAsset<T> : AbstractAsset, IArrayAsset
+    public class _2DArrayAsset : AbstractAsset
     {
         public int Width { get; }
         public int Height { get; }
-        public int Type { get; }
-        public T[] Data { get; }
+        public int ElementSize { get; }
+        public byte[] Data { get; }
 
-        public _2DArrayAsset(int width, int height, int type, T[] data)
+        private IArrayView _autoCommitView;
+
+        public _2DArrayAsset(int width, int height, int elementSize, byte[] data)
         {
             Width = width;
             Height = height;
-            Type = type;
+            ElementSize = elementSize;
             Data = data;
         }
 
-        public override string ToString()
+        public _2DArrayView<T> GetView<T>(bool autoCommit) where T : unmanaged
         {
-            StringBuilder result = new StringBuilder();
-
-            int padding = typeof(T) == typeof(float) ? 6 : 3;
-            int i = 0;
-
-            for (int y = 0; y < Height; y++)
+            if (autoCommit && _autoCommitView != null)
             {
-                for (int x = 0; x < Width; x++)
+                if (typeof(T) == _autoCommitView.ArrayType())
                 {
-                    result.Append(Data[i++].ToString().PadRight(padding) + " ");
+                    return (_2DArrayView<T>)_autoCommitView;
                 }
 
-                result.AppendLine();
+                throw new InvalidOperationException("Cannot have more than one view of a 2d array with auto commit enabled.");
             }
 
-            return $"Array {TGI.InstanceID}: \n {result}";
+            var view = new _2DArrayView<T>(this);
+
+            if (autoCommit)
+            {
+                _autoCommitView = view;
+            }
+
+            return view;
         }
 
-        public Type ArrayType()
+        public void AutoCommit()
         {
-            return typeof(T);
+            if (_autoCommitView != null)
+            {
+                _autoCommitView.Commit();
+            }
         }
     }
 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Text;
+
+namespace OpenTS2.Content.DBPF
+{
+    public interface IArrayAsset
+    {
+        Type ArrayType();
+    }
+
+    /// <summary>
+    /// Contains a 2D Array of data.
+    /// </summary>
+    public class _2DArrayAsset<T> : AbstractAsset, IArrayAsset
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public int Type { get; }
+        public T[] Data { get; }
+
+        public _2DArrayAsset(int width, int height, int type, T[] data)
+        {
+            Width = width;
+            Height = height;
+            Type = type;
+            Data = data;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+
+            int padding = typeof(T) == typeof(float) ? 6 : 3;
+            int i = 0;
+
+            for (int y = 0; y < Height; y++)
+            {
+                for (int x = 0; x < Width; x++)
+                {
+                    result.Append(Data[i++].ToString().PadRight(padding) + " ");
+                }
+
+                result.AppendLine();
+            }
+
+            return $"Array {TGI.InstanceID}: \n {result}";
+        }
+
+        public Type ArrayType()
+        {
+            return typeof(T);
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_2DArrayAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 635eda687c9c05b4497373a3761197ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Text;
+
+namespace OpenTS2.Content.DBPF
+{
+    public interface ID2ArrayAsset
+    {
+        Type ArrayType();
+    }
+
+    /// <summary>
+    /// Contains a 2D Array of data.
+    /// </summary>
+    public class _3DArrayAsset<T> : AbstractAsset, IArrayAsset
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public int Depth { get; }
+        public int Type { get; }
+
+        /// <summary>
+        /// Note: data is encoded in consecutive vertical strips, unlike 2d array which is horizontal
+        /// </summary>
+        public T[][] Data { get; }
+
+        public _3DArrayAsset(int width, int height, int depth, int type, T[][] data)
+        {
+            Width = width;
+            Height = height;
+            Depth = depth;
+            Type = type;
+            Data = data;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+
+            int padding = typeof(T) == typeof(float) ? 6 : 3;
+
+            for (int z = 0; z < Depth; z++)
+            {
+                var data = Data[z];
+
+                int i = 0;
+                for (int x = 0; x < Width; x++)
+                {
+                    for (int y = 0; y < Height; y++)
+                    {
+                        var stringValue = $"{data[i++]}";
+                        result.Append(stringValue.PadRight(padding) + " ");
+                    }
+
+                    result.AppendLine();
+                }
+
+                result.AppendLine();
+            }
+
+            return $"Array {TGI.InstanceID} ({Width}x{Height}x{Depth}): \n {result}";
+        }
+
+        public Type ArrayType()
+        {
+            return typeof(T);
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs
@@ -1,68 +1,188 @@
+using OpenTS2.Files.Utils;
 using System;
-using System.Text;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace OpenTS2.Content.DBPF
 {
-    public interface ID2ArrayAsset
+    public interface I3DArrayView : IArrayView
     {
-        Type ArrayType();
+        void Resize(int newDepth);
     }
 
     /// <summary>
-    /// Contains a 2D Array of data.
+    /// A typed view into a 3D array.
+    /// This is essentially a copy of the base data. It should be committed to save back to the parent array.
     /// </summary>
-    public class _3DArrayAsset<T> : AbstractAsset, IArrayAsset
+    /// <typeparam name="T">Array element type</typeparam>
+    public class _3DArrayView<T> : IArrayView where T : unmanaged
+    {
+        public _3DArrayAsset Parent { get; }
+        public int Width { get; }
+        public int Height { get; }
+        public int Depth { get; private set; }
+        public T[][] Data => _data;
+
+        private T[][] _data;
+
+        public _3DArrayView(_3DArrayAsset asset)
+        {
+            if (UnsafeUtility.SizeOf<T>() != asset.ElementSize)
+            {
+                throw new InvalidOperationException($"3D array view made of type {typeof(T).Name} with expected element size {UnsafeUtility.SizeOf<T>()}, but source data is for element size {asset.ElementSize}.");
+            }
+
+            Parent = asset;
+            Width = asset.Width;
+            Height = asset.Height;
+            Depth = asset.Depth;
+            _data = new T[Depth][];
+
+            for (int i = 0; i < Depth; i++)
+            {
+                _data[i] = new T[Width * Height];
+            }
+
+            Update();
+        }
+
+        /// <summary>
+        /// Resize the array view with a new depth.
+        /// This will apply to the parent when Commit is called, but can be reset by Update.
+        /// </summary>
+        /// <param name="newDepth">The new depth for the 3d array</param>
+        public void Resize(int newDepth)
+        {
+            Array.Resize(ref _data, newDepth);
+
+            for (int i = Depth; i < newDepth; i++)
+            {
+                _data[i] = new T[Width * Height];
+            }
+
+            Depth = newDepth;
+        }
+
+        /// <summary>
+        /// Take values from the parent 2D array.
+        /// </summary>
+        public void Update()
+        {
+            // Ensure this array has the same depth as the source.
+
+            if (Depth != Parent.Depth)
+            {
+                Resize(Parent.Depth);
+            }
+
+            for (int i = 0; i < Depth; i++)
+            {
+                ReinterpretCast.Copy(Parent.Data[i], _data[i], _data[i].Length * Parent.ElementSize);
+            }
+        }
+
+        /// <summary>
+        /// Commit changes back to the parent 2D array.
+        /// </summary>
+        public void Commit()
+        {
+            // Ensure the source array has the same depth as this.
+
+            if (Depth != Parent.Depth)
+            {
+                Parent.Resize(Depth);
+            }
+
+            for (int i = 0; i < Depth; i++)
+            {
+                ReinterpretCast.Copy(_data[i], Parent.Data[i], _data[i].Length * Parent.ElementSize);
+            }
+        }
+
+        /// <summary>
+        /// Get the type of the array view.
+        /// </summary>
+        /// <returns>The array view type</returns>
+        public Type ArrayType()
+        {
+            return typeof(T);
+        }
+    }
+
+    /// <summary>
+    /// Contains a 3D Array of data.
+    /// </summary>
+    public class _3DArrayAsset : AbstractAsset
     {
         public int Width { get; }
         public int Height { get; }
-        public int Depth { get; }
-        public int Type { get; }
+        public int ElementSize { get; private set; }
+        public int Depth { get; private set; }
 
         /// <summary>
         /// Note: data is encoded in consecutive vertical strips, unlike 2d array which is horizontal
         /// </summary>
-        public T[][] Data { get; }
+        public byte[][] Data => _data;
 
-        public _3DArrayAsset(int width, int height, int depth, int type, T[][] data)
+        private byte[][] _data;
+
+        private IArrayView _autoCommitView;
+
+        public _3DArrayAsset(int width, int height, int depth, int elementSize, byte[][] data)
         {
             Width = width;
             Height = height;
             Depth = depth;
-            Type = type;
-            Data = data;
+            ElementSize = elementSize;
+            _data = data;
         }
 
-        public override string ToString()
+        public void Resize(int newDepth)
         {
-            StringBuilder result = new StringBuilder();
+            Array.Resize(ref _data, newDepth);
 
-            int padding = typeof(T) == typeof(float) ? 6 : 3;
-
-            for (int z = 0; z < Depth; z++)
+            for (int i = Depth; i < newDepth; i++)
             {
-                var data = Data[z];
-
-                int i = 0;
-                for (int x = 0; x < Width; x++)
-                {
-                    for (int y = 0; y < Height; y++)
-                    {
-                        var stringValue = $"{data[i++]}";
-                        result.Append(stringValue.PadRight(padding) + " ");
-                    }
-
-                    result.AppendLine();
-                }
-
-                result.AppendLine();
+                _data[i] = new byte[Width * Height * ElementSize];
             }
 
-            return $"Array {TGI.InstanceID} ({Width}x{Height}x{Depth}): \n {result}";
+            Depth = newDepth;
         }
 
-        public Type ArrayType()
+        public _3DArrayView<T> GetView<T>(bool autoCommit) where T : unmanaged
         {
-            return typeof(T);
+            if (ElementSize == 0)
+            {
+                // Element size may not be known if the depth is 0.
+                // Inherit the first view's size if that is the case.
+                ElementSize = UnsafeUtility.SizeOf<T>();
+            }
+
+            if (autoCommit && _autoCommitView != null)
+            {
+                if (typeof(T) == _autoCommitView.ArrayType())
+                {
+                    return (_3DArrayView<T>)_autoCommitView;
+                }
+
+                throw new InvalidOperationException("Cannot have more than one view of a 3d array with auto commit enabled.");
+            }
+
+            var view = new _3DArrayView<T>(this);
+
+            if (autoCommit)
+            {
+                _autoCommitView = view;
+            }
+
+            return view;
+        }
+
+        public void AutoCommit()
+        {
+            if (_autoCommitView != null)
+            {
+                _autoCommitView.Commit();
+            }
         }
     }
 

--- a/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs.meta
+++ b/Assets/Scripts/OpenTS2/Content/DBPF/_3DArrayAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 854a19727cfecbc44814024c0a111745
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Engine/Main.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Main.cs
@@ -30,6 +30,7 @@ namespace OpenTS2.Engine
             var contentProvider = new ContentProvider();
             var objectManager = new ObjectManager(contentProvider);
             var effectsManager = new EffectsManager(contentProvider);
+            var catalogManager = new CatalogManager(contentProvider);
             var luaManager = new LuaManager();
 
             TerrainManager.Initialize();

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenTS2.Common;
@@ -7,10 +8,9 @@ using OpenTS2.Content.DBPF;
 using OpenTS2.Content.DBPF.Scenegraph;
 using OpenTS2.Files;
 using OpenTS2.Files.Formats.DBPF;
-using OpenTS2.Files.Formats.DBPF.Scenegraph;
-using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
 using OpenTS2.Scenes.Lot;
 using OpenTS2.Scenes.Lot.Roof;
+using UnityEditor;
 using UnityEngine;
 
 namespace OpenTS2.Engine.Tests
@@ -18,29 +18,73 @@ namespace OpenTS2.Engine.Tests
     public class LotLoadingTest : MonoBehaviour
     {
         public string NeighborhoodPrefix = "N001";
-        public int LotID = 10;
+        public int LotID = 82;
 
+        private string _nhood;
+        private int _lotId;
+
+        private List<GameObject> _lotObject = new List<GameObject>();
+
+        private void UnloadLot()
+        {
+            foreach (var obj in _lotObject)
+            {
+                Destroy(obj);
+            }
+        }
 
         private void Start()
         {
+            // Load effects.
+            EffectsManager.Get().Initialize();
+
+            ContentLoading.LoadGameContentSync();
+
+            CatalogManager.Get().Initialize();
+
+            LoadLot(NeighborhoodPrefix, LotID);
+        }
+
+        public void Changed()
+        {
+            if (NeighborhoodPrefix != _nhood)
+            {
+                StartCoroutine(ReloadLot());
+            }
+            else if (LotID != _lotId)
+            {
+                StartCoroutine(ReloadLot());
+            }
+        }
+
+        System.Collections.IEnumerator ReloadLot()
+        {
+            yield return new WaitForFixedUpdate();
+
+            if (NeighborhoodPrefix != _nhood || LotID != _lotId)
+            {
+                UnloadLot();
+                LoadLot(NeighborhoodPrefix, LotID);
+            }
+        }
+
+        private void LoadLot(string neighborhoodPrefix, int id)
+        {
+            _nhood = neighborhoodPrefix;
+            _lotId = id;
+
             var contentProvider = ContentProvider.Get();
+
             var lotsFolderPath = Path.Combine(Filesystem.GetUserPath(), $"Neighborhoods/{NeighborhoodPrefix}/Lots");
             var lotFilename = $"{NeighborhoodPrefix}_Lot{LotID}.package";
             var lotFullPath = Path.Combine(lotsFolderPath, lotFilename);
+
+            if (!File.Exists(lotFullPath))
+            {
+                return;
+            }
+
             var lotPackage = contentProvider.AddPackage(lotFullPath);
-
-            // Load effects.
-            EffectsManager.Get().Initialize();
-            // Load base game assets.
-            contentProvider.AddPackages(
-                Filesystem.GetPackagesInDirectory(Filesystem.GetDataPathForProduct(ProductFlags.BaseGame) +
-                                                  "/Res/Sims3D"));
-            // Load patterns catalog.
-            contentProvider.AddPackages(
-                Filesystem.GetPackagesInDirectory(Filesystem.GetDataPathForProduct(ProductFlags.BaseGame) +
-                                                  "/Res/Catalog/Patterns"));
-
-            CatalogManager.Get().Initialize();
 
             // Go through each lot object.
             foreach (var entry in lotPackage.Entries)
@@ -65,6 +109,8 @@ namespace OpenTS2.Engine.Tests
                     var model = resource.CreateRootGameObject();
                     model.transform.GetChild(0).localPosition = lotObject.Object.Position;
                     model.transform.GetChild(0).localRotation = lotObject.Object.Rotation;
+
+                    _lotObject.Add(model);
                 }
                 catch (Exception e)
                 {
@@ -93,6 +139,7 @@ namespace OpenTS2.Engine.Tests
 
             var roofObj = new GameObject("roof", typeof(LotRoofComponent));
             roofObj.GetComponent<LotRoofComponent>().CreateFromLotAssets(roof.Entries.FirstOrDefault().Pattern, roofs);
+            _lotObject.Add(roofObj);
 
             // Walls
 
@@ -101,6 +148,7 @@ namespace OpenTS2.Engine.Tests
 
             var wall = new GameObject("wall", typeof(LotWallComponent));
             wall.GetComponent<LotWallComponent>().CreateFromLotAssets(wallStyles, wallLayer, wallGraphR, fencePosts, floorElevation, roofs);
+            _lotObject.Add(wall);
 
             // Floors
 
@@ -110,6 +158,7 @@ namespace OpenTS2.Engine.Tests
             floor.GetComponent<LotFloorComponent>().CreateFromLotAssets(floorStyles, floorPatterns, floorElevation, wallGraph.BaseFloor);
             // Small bias until the floor is cut out of the terrain.
             floor.transform.position = new Vector3(0, 0.001f, 0);
+            _lotObject.Add(floor);
 
             // Terrain
 
@@ -125,6 +174,97 @@ namespace OpenTS2.Engine.Tests
 
             var terrain = new GameObject("terrain", typeof(LotTerrainComponent));
             terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(terrainTextures, floorElevation, blend, wallGraph.BaseFloor);
+            _lotObject.Add(terrain);
+        }
+    }
+
+    [CustomEditor(typeof(LotLoadingTest))]
+    public class LotLoadingTestEditor : Editor
+    {
+        private string _cachedNhood = "";
+        private List<string> NhoodNames = new List<string>() { "N001" };
+        private List<int> LotIds = new List<int>() { 82 };
+
+        public LotLoadingTestEditor()
+        {
+            PopulateNhoodList();
+        }
+
+        private void PopulateNhoodList()
+        {
+            NhoodNames.Clear();
+
+            var nhoodFolderPath = Path.Combine(Filesystem.GetUserPath(), $"Neighborhoods");
+
+            foreach (var nhood in Directory.GetDirectories(nhoodFolderPath))
+            {
+                string filename = Path.GetFileName(nhood);
+
+                if (filename.Length == 4)
+                {
+                    NhoodNames.Add(filename);
+                }
+            }
+        }
+
+        private void PopulateLotList(string nhood)
+        {
+            _cachedNhood = nhood;
+            var lotsFolderPath = Path.Combine(Filesystem.GetUserPath(), $"Neighborhoods/{nhood}/Lots");
+
+            LotIds.Clear();
+
+            try
+            {
+                foreach (string file in Directory.GetFiles(lotsFolderPath))
+                {
+                    if (file.EndsWith(".package"))
+                    {
+                        int tIndex = file.LastIndexOf('t');
+                        int end = file.Length - ".package".Length;
+                        string lotIdProbably = file.Substring(tIndex + 1, end - (tIndex + 1));
+
+                        if (int.TryParse(lotIdProbably, out int lotId))
+                        {
+                            LotIds.Add(lotId);
+                        }
+                    }
+                }
+            }
+            catch
+            {
+
+            }
+
+            LotIds.Sort();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var test = target as LotLoadingTest;
+
+            Main.Initialize();
+
+            string[] noptions = NhoodNames.ToArray();
+            int nindex = EditorGUILayout.Popup("Neighborhood", NhoodNames.IndexOf(test.NeighborhoodPrefix), noptions);
+            if (nindex > -1)
+            {
+                test.NeighborhoodPrefix = NhoodNames[nindex];
+            }
+
+            if (test.NeighborhoodPrefix != _cachedNhood)
+            {
+                PopulateLotList(test.NeighborhoodPrefix);
+            }
+
+            string[] options = LotIds.Select(x => "Lot " + x.ToString()).ToArray();
+            int index = EditorGUILayout.Popup("Lot ID", LotIds.IndexOf(test.LotID), options);
+            if (index > -1)
+            {
+                test.LotID = LotIds[index];
+            }
+
+            test.Changed();
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -150,9 +150,6 @@ namespace OpenTS2.Engine.Tests
             wall.GetComponent<LotWallComponent>().CreateFromLotAssets(wallStyles, wallLayer, wallGraphR, fencePosts, floorElevation, roofs);
             _lotObject.Add(wall);
 
-            // Small bias otherwise wall tops cut through floors a bit.
-            wall.transform.position = new Vector3(0, -0.001f, 0);
-
             // Floors
 
             var floorPatterns = lotPackage.GetAssetByTGI<_3DArrayAsset<Vector4<ushort>>>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_3ARY));

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -165,7 +165,7 @@ namespace OpenTS2.Engine.Tests
             var terrainTextures = lotPackage.Entries.First(x => x.GlobalTGI.TypeID == TypeIDs.LOT_TEXTURES).GetAsset<LotTexturesAsset>();
             var terrainData = lotPackage.Entries.Where(x => x.GlobalTGI.TypeID == TypeIDs.LOT_TERRAIN).Select(x => x.GetAsset()).ToList();
 
-            var heightmap = (_2DArrayAsset<float>)terrainData.First(x => x is IArrayAsset array && array.ArrayType() == typeof(float));
+            var waterHeightmap = (_2DArrayAsset<float>)terrainData.First(x => x is IArrayAsset array && array.ArrayType() == typeof(float));
             var blend = terrainData.Where(x => x is IArrayAsset array && array.ArrayType() == typeof(byte))
                 .OrderBy(x => x.GlobalTGI.InstanceID)
                 .Select(x => (_2DArrayAsset<byte>)x)
@@ -173,7 +173,7 @@ namespace OpenTS2.Engine.Tests
                 .ToArray();
 
             var terrain = new GameObject("terrain", typeof(LotTerrainComponent));
-            terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(terrainTextures, floorElevation, blend, wallGraph.BaseFloor);
+            terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(terrainTextures, floorElevation, blend, waterHeightmap, wallGraph.BaseFloor);
             _lotObject.Add(terrain);
         }
     }

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -150,14 +150,15 @@ namespace OpenTS2.Engine.Tests
             wall.GetComponent<LotWallComponent>().CreateFromLotAssets(wallStyles, wallLayer, wallGraphR, fencePosts, floorElevation, roofs);
             _lotObject.Add(wall);
 
+            // Small bias otherwise wall tops cut through floors a bit.
+            wall.transform.position = new Vector3(0, -0.001f, 0);
+
             // Floors
 
             var floorPatterns = lotPackage.GetAssetByTGI<_3DArrayAsset<Vector4<ushort>>>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_3ARY));
 
             var floor = new GameObject("floor", typeof(LotFloorComponent));
             floor.GetComponent<LotFloorComponent>().CreateFromLotAssets(floorStyles, floorPatterns, floorElevation, wallGraph.BaseFloor);
-            // Small bias until the floor is cut out of the terrain.
-            floor.transform.position = new Vector3(0, 0.001f, 0);
             _lotObject.Add(floor);
 
             // Terrain
@@ -173,7 +174,7 @@ namespace OpenTS2.Engine.Tests
                 .ToArray();
 
             var terrain = new GameObject("terrain", typeof(LotTerrainComponent));
-            terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(terrainTextures, floorElevation, blend, waterHeightmap, wallGraph.BaseFloor);
+            terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(terrainTextures, floorElevation, blend, waterHeightmap, floorPatterns, wallGraph.BaseFloor);
             _lotObject.Add(terrain);
         }
     }

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -170,7 +170,9 @@ namespace OpenTS2.Engine.Tests
             _architecture.LoadFromPackage(lotPackage);
             _architecture.CreateGameObjects(_lotObject);
 
-            _state = new WorldState(_architecture.FloorPatterns.Depth, WallsMode.Roof);
+            Floor = MaxFloor + BaseFloor;
+            Mode = WallsMode.Roof;
+            _state = new WorldState(Floor, Mode);
             _architecture.UpdateState(_state);
         }
     }

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -129,7 +129,7 @@ namespace OpenTS2.Engine.Tests
 
             var wallLayer = lotPackage.GetAssetByTGI<WallLayerAsset>(new ResourceKey(4, uint.MaxValue, TypeIDs.LOT_WALLLAYER));
             var wallGraph = lotPackage.GetAssetByTGI<WallGraphAsset>(new ResourceKey(0x18, uint.MaxValue, TypeIDs.LOT_WALLGRAPH));
-            var floorElevation = lotPackage.GetAssetByTGI<_3DArrayAsset<float>>(new ResourceKey(1, uint.MaxValue, TypeIDs.LOT_3ARY));
+            var floorElevation = lotPackage.GetAssetByTGI<_3DArrayAsset>(new ResourceKey(1, uint.MaxValue, TypeIDs.LOT_3ARY)).GetView<float>(true);
             var pool = lotPackage.GetAssetByTGI<PoolAsset>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_POOL));
             var roof = lotPackage.GetAssetByTGI<RoofAsset>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_ROOF));
 
@@ -152,7 +152,7 @@ namespace OpenTS2.Engine.Tests
 
             // Floors
 
-            var floorPatterns = lotPackage.GetAssetByTGI<_3DArrayAsset<Vector4<ushort>>>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_3ARY));
+            var floorPatterns = lotPackage.GetAssetByTGI<_3DArrayAsset>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_3ARY)).GetView<Vector4<ushort>>(true);
 
             var floor = new GameObject("floor", typeof(LotFloorComponent));
             floor.GetComponent<LotFloorComponent>().CreateFromLotAssets(floorStyles, floorPatterns, floorElevation, wallGraph.BaseFloor);
@@ -163,10 +163,10 @@ namespace OpenTS2.Engine.Tests
             var terrainTextures = lotPackage.Entries.First(x => x.GlobalTGI.TypeID == TypeIDs.LOT_TEXTURES).GetAsset<LotTexturesAsset>();
             var terrainData = lotPackage.Entries.Where(x => x.GlobalTGI.TypeID == TypeIDs.LOT_TERRAIN).Select(x => x.GetAsset()).ToList();
 
-            var waterHeightmap = (_2DArrayAsset<float>)terrainData.First(x => x is IArrayAsset array && array.ArrayType() == typeof(float));
-            var blend = terrainData.Where(x => x is IArrayAsset array && array.ArrayType() == typeof(byte))
+            var waterHeightmap = ((_2DArrayAsset)terrainData.First(x => x is _2DArrayAsset array && array.ElementSize == 4)).GetView<float>(true);
+            var blend = terrainData.Where(x => x is _2DArrayAsset array && array.ElementSize == 1)
                 .OrderBy(x => x.GlobalTGI.InstanceID)
-                .Select(x => (_2DArrayAsset<byte>)x)
+                .Select(x => ((_2DArrayAsset)x).GetView<byte>(true))
                 .Take(terrainTextures.BlendTextures.Length)
                 .ToArray();
 

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -23,7 +23,6 @@ namespace OpenTS2.Engine.Tests
 
         private void Start()
         {
-            LotID = 80;
             var contentProvider = ContentProvider.Get();
             var lotsFolderPath = Path.Combine(Filesystem.GetUserPath(), $"Neighborhoods/{NeighborhoodPrefix}/Lots");
             var lotFilename = $"{NeighborhoodPrefix}_Lot{LotID}.package";

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -100,11 +100,13 @@ namespace OpenTS2.Engine.Tests
 
             // Shared
 
+            var wallLayer = lotPackage.GetAssetByTGI<WallLayerAsset>(new ResourceKey(4, uint.MaxValue, TypeIDs.LOT_WALLLAYER));
+            var wallGraph = lotPackage.GetAssetByTGI<WallGraphAsset>(new ResourceKey(0x18, uint.MaxValue, TypeIDs.LOT_WALLGRAPH));
             var floorElevation = lotPackage.GetAssetByTGI<_3DArrayAsset<float>>(new ResourceKey(1, uint.MaxValue, TypeIDs.LOT_3ARY));
             var pool = lotPackage.GetAssetByTGI<PoolAsset>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_POOL));
             var roof = lotPackage.GetAssetByTGI<RoofAsset>(new ResourceKey(0, uint.MaxValue, TypeIDs.LOT_ROOF));
 
-            var roofs = new RoofCollection(roof.Entries, floorElevation);
+            var roofs = new RoofCollection(roof.Entries, floorElevation, wallGraph.BaseFloor);
 
             // Roofs
 
@@ -113,8 +115,6 @@ namespace OpenTS2.Engine.Tests
 
             // Walls
 
-            var wallLayer = lotPackage.GetAssetByTGI<WallLayerAsset>(new ResourceKey(4, uint.MaxValue, TypeIDs.LOT_WALLLAYER));
-            var wallGraph = lotPackage.GetAssetByTGI<WallGraphAsset>(new ResourceKey(0x18, uint.MaxValue, TypeIDs.LOT_WALLGRAPH));
             var wallGraphR = wallGraph;
             var fencePosts = lotPackage.GetAssetByTGI<FencePostLayerAsset>(new ResourceKey(0x11, uint.MaxValue, TypeIDs.LOT_FENCEPOST));
 

--- a/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
+++ b/Assets/Scripts/OpenTS2/Engine/Tests/LotLoadingTest.cs
@@ -66,24 +66,6 @@ namespace OpenTS2.Engine.Tests
                     var model = resource.CreateRootGameObject();
                     model.transform.GetChild(0).localPosition = lotObject.Object.Position;
                     model.transform.GetChild(0).localRotation = lotObject.Object.Rotation;
-
-                    // Object wall cuts
-                    // This would probably normally be evaluated by iterating subtile parts to get x/y, then wall placement flags in OBJD.
-                    // But we don't access that right now, so get wall masks corresponding to light resources in the cres.
-
-                    /*
-                    var lights = resource.ResourceCollection.Blocks.Select(block => {
-                        if (block is LightRefNodeBlock light)
-                        {
-                            return contentProvider.GetAsset<ScenegraphResourceAsset>(resource.ResourceCollection.FileLinks[((ExternalReference)light.Light).FileLinksIndex]);
-                        }
-                    }).ToArray();
-
-                    if (lights.Length > 0)
-                    {
-
-                    }
-                    */
                 }
                 catch (Exception e)
                 {

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.CATALOG_FENCE)]
+    public class CatalogFenceCodec : AbstractCodec
+    {
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            try
+            {
+                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+
+                return new CatalogFenceAsset(propertySet);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs
@@ -14,7 +14,7 @@ namespace OpenTS2.Files.Formats.DBPF
         {
             try
             {
-                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+                var propertySet = new PropertySet(bytes);
 
                 return new CatalogFenceAsset(propertySet);
             }

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogFenceCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffec714e3c2034e42ae302731ff84d3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs
@@ -14,7 +14,7 @@ namespace OpenTS2.Files.Formats.DBPF
         {
             try
             {
-                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+                var propertySet = new PropertySet(bytes);
 
                 return new CatalogObjectAsset(propertySet);
             }

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.CATALOG_OBJECT)]
+    public class CatalogObjectCodec : AbstractCodec
+    {
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            try
+            {
+                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+
+                return new CatalogObjectAsset(propertySet);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogObjectCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df304add208af9b459f1ef88a530d532
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Formats.XML;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.CATALOG_ROOF)]
+    public class CatalogRoofCodec : AbstractCodec
+    {
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            try
+            {
+                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+
+                return new CatalogRoofAsset(propertySet);
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs
@@ -14,7 +14,7 @@ namespace OpenTS2.Files.Formats.DBPF
         {
             try
             {
-                var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+                var propertySet = new PropertySet(bytes);
 
                 return new CatalogRoofAsset(propertySet);
             }

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/CatalogRoofCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf0fe8256ffe9864caf632d87d139a16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/FencePostLayerCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/FencePostLayerCodec.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_FENCEPOST)]
+    public class FencePostLayerCodec : AbstractCodec
+    {
+        private const uint TypeId = 0xab4ba572;
+        private const int Version = 1;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"FPST has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version == Version, "Wrong version for FPST");
+
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "cFencePostLayer")
+            {
+                throw new ArgumentException($"FPST has wrong block name {blockName}");
+            }
+
+            int count = reader.ReadInt32();
+
+            var entries = new FencePost[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                entries[i] = new FencePost()
+                {
+                    Level = reader.ReadInt32(),
+                    XPos = reader.ReadFloat(),
+                    YPos = reader.ReadFloat(),
+                    GUID = reader.ReadUInt32()
+                };
+            }
+
+            return new FencePostLayerAsset(entries);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/FencePostLayerCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/FencePostLayerCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bd5194d9327c74439d45cd59097c821
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/GroupsTypes.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/GroupsTypes.cs
@@ -46,6 +46,7 @@ namespace OpenTS2.Files.Formats.DBPF
         public const uint LOT_3ARY = 0x2A51171B;
         public const uint CATALOG_OBJECT = 0xCCA8E925;
         public const uint CATALOG_FENCE = 0x2CB230B8;
+        public const uint CATALOG_ROOF = 0xACA8EA06;
         public const uint STR = 0x53545223;
         public const uint IMG = 0x856DDBAC;
         public const uint IMG2 = 0x8C3CE95A;

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/GroupsTypes.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/GroupsTypes.cs
@@ -35,6 +35,17 @@ namespace OpenTS2.Files.Formats.DBPF
         // cTSLotInfo in game / Lot Description in SimsPE.
         public const uint LOT_INFO = 0x0BF999E7;
         public const uint LOT_OBJECT = 0xFA1C39F7;
+        public const uint LOT_TERRAIN = 0x6B943B43;
+        public const uint LOT_TEXTURES = 0x4B58975B;
+        public const uint LOT_FENCEPOST = 0xAB4BA572;
+        public const uint LOT_POOL = 0x0C900FDB;
+        public const uint LOT_ROOF = 0xAB9406AA;
+        public const uint LOT_WALLGRAPH = 0x0A284D0B;
+        public const uint LOT_WALLLAYER = 0x8A84D7B0;
+        public const uint LOT_STRINGMAP = 0xCAC4FC40;
+        public const uint LOT_3ARY = 0x2A51171B;
+        public const uint CATALOG_OBJECT = 0xCCA8E925;
+        public const uint CATALOG_FENCE = 0x2CB230B8;
         public const uint STR = 0x53545223;
         public const uint IMG = 0x856DDBAC;
         public const uint IMG2 = 0x8C3CE95A;

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/LotTexturesCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/LotTexturesCodec.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_TEXTURES)]
+    public class LotTexturesCodec : AbstractCodec
+    {
+        private const uint TypeId = 0x4B58975B;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"LTTX has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version == 7, "Wrong version for LTTX");
+
+            int width = reader.ReadInt32();
+            int height = reader.ReadInt32();
+
+            string baseTexture = reader.ReadVariableLengthPascalString();
+
+            int blendCount = reader.ReadInt32();
+
+            string[] blendTextures = new string[blendCount];
+
+            for (int i = 0; i < blendCount; i++)
+            {
+                blendTextures[i] = reader.ReadVariableLengthPascalString();
+            }
+
+            return new LotTexturesAsset(width, height, baseTexture, blendTextures);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/LotTexturesCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/LotTexturesCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b8ea23d2221dfa4ebe5c909aa2d84f6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/NeighborhoodObjectCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/NeighborhoodObjectCodec.cs
@@ -12,7 +12,7 @@ namespace OpenTS2.Files.Formats.DBPF
     {
         public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
         {
-            var propertySet = new PropertySet(Encoding.UTF8.GetString(bytes));
+            var propertySet = new PropertySet(bytes);
 
             var modelName = propertySet.GetProperty<StringProp>("modelname").Value;
             // Yup, the game just tacks on a _cres to the end of this.

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs
@@ -40,7 +40,7 @@ namespace OpenTS2.Files.Formats.DBPF
             {
                 entries[i] = new PoolEntry()
                 {
-                    Unknown1 = reader.ReadInt32(),
+                    Id = reader.ReadInt32(),
                     XPos = reader.ReadFloat(),
                     YPos = reader.ReadFloat(),
                     Level = reader.ReadInt32(),

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_POOL)]
+    public class PoolCodec : AbstractCodec
+    {
+        private const uint TypeId = 0x0c900fdb;
+        private const int Version = 1;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"POOL has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version == Version, "Wrong version for POOL");
+
+            int count = reader.ReadInt32();
+
+            var entries = new PoolEntry[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                entries[i] = new PoolEntry()
+                {
+                    Unknown1 = reader.ReadInt32(),
+                    XPos = reader.ReadFloat(),
+                    YPos = reader.ReadFloat(),
+                    Level = reader.ReadInt32(),
+                    XSize = reader.ReadInt32(),
+                    YSize = reader.ReadInt32(),
+                    Unknown2 = reader.ReadInt32(),
+                    YOffset = reader.ReadFloat(),
+                    Unknown3 = reader.ReadInt32()
+                };
+            }
+
+            return new PoolAsset(entries);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/PoolCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea397618da9512742917f15b6a0d8ba8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_ROOF)]
+    public class RoofCodec : AbstractCodec
+    {
+        private const uint TypeId = 0xab9406aa;
+        private const int VersionMin = 1;
+        private const int VersionMax = 3;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"ROOF has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version >= VersionMin || version <= VersionMax, "Wrong version for ROOF");
+
+            int count = reader.ReadInt32();
+
+            var entries = new RoofEntry[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                entries[i] = new RoofEntry()
+                {
+                    Id = reader.ReadInt32(),
+                    XFrom = reader.ReadFloat(),
+                    YFrom = reader.ReadFloat(),
+                    LevelFrom = reader.ReadInt32(),
+                    XTo = reader.ReadFloat(),
+                    YTo = reader.ReadFloat(),
+                    LevelTo = reader.ReadInt32(),
+                    Type = (RoofType)reader.ReadInt32(),
+                    Pattern = reader.ReadInt32(),
+
+                    RoofAngle = version >= 2 ? reader.ReadFloat() : 0.5f,
+                    RoofStyleExtended = version >= 3 ? reader.ReadInt32() : 0 // 3 for gable roof on an example?
+                };
+            }
+
+            return new RoofAsset(entries);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs
@@ -49,7 +49,7 @@ namespace OpenTS2.Files.Formats.DBPF
                     YTo = reader.ReadFloat(),
                     LevelTo = reader.ReadInt32(),
                     Type = (RoofType)reader.ReadInt32(),
-                    Pattern = reader.ReadInt32(),
+                    Pattern = reader.ReadUInt32(),
 
                     RoofAngle = version >= 2 ? reader.ReadFloat() : 0.5f,
                     RoofStyleExtended = version >= 3 ? reader.ReadInt32() : 0 // 3 for gable roof on an example?

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/RoofCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 186b4cdd1f03fc04f84187b3b2ae409c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_STRINGMAP)]
+    public class StringMapCodec : AbstractCodec
+    {
+        private const uint TypeId = 0xcac4fc40;
+        private const int Version = 1;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"SMAP has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version == Version, "Wrong version for SMAP");
+
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "cStringMap")
+            {
+                throw new ArgumentException($"SMAP has wrong block name {blockName}");
+            }
+
+            int count = reader.ReadInt32();
+
+            var entries = new StringMapEntry[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                entries[i] = new StringMapEntry()
+                {
+                    Value = reader.ReadVariableLengthPascalString(),
+                    Id = reader.ReadUInt16(),
+                    Unknown1 = reader.ReadUInt16(),
+                    Unknown2 = reader.ReadUInt16()
+                };
+            }
+
+            return new StringMapAsset(entries);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs
@@ -49,8 +49,7 @@ namespace OpenTS2.Files.Formats.DBPF
                 {
                     Value = reader.ReadVariableLengthPascalString(),
                     Id = reader.ReadUInt16(),
-                    Unknown1 = reader.ReadUInt16(),
-                    Unknown2 = reader.ReadUInt16()
+                    Unknown = reader.ReadUInt32()
                 };
             }
 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/StringMapCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56111f9ab5b3bd242ba787369af948f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallGraphCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallGraphCodec.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_WALLGRAPH)]
+    public class WallGraphCodec : AbstractCodec
+    {
+        private const uint TypeId = 0x0a284d0b;
+        private const int Version = 2;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"WGRA has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version >= Version, "Wrong version for WGRA");
+
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "cWallGraph")
+            {
+                throw new ArgumentException($"WGRA has wrong block name {blockName}");
+            }
+
+            int unk1 = reader.ReadInt32();
+            int unk2 = reader.ReadInt32();
+            int baseFloor = reader.ReadInt32();
+
+            if (unk1 != 0 || unk2 != 0)
+            {
+                throw new ArgumentException($"Unexpected WGRA header, should be all 0");
+            }
+
+            int width = reader.ReadInt32();
+            int height = reader.ReadInt32();
+            int floors = reader.ReadInt32();
+
+            // Not sure what these IDs are for. The second is generally higher than the first.
+            int id1 = reader.ReadInt32();
+            int id2 = reader.ReadInt32();
+            int posCount = reader.ReadInt32();
+
+            var pos = new WallGraphPositionEntry[posCount];
+
+            for (int i = 0; i < posCount; i++)
+            {
+                pos[i] = new WallGraphPositionEntry()
+                {
+                    Id = reader.ReadInt32(),
+                    XPos = reader.ReadFloat(),
+                    YPos = reader.ReadFloat(),
+                    Level = reader.ReadInt32(),
+                };
+            }
+
+            int idCount = reader.ReadInt32();
+            int[] rooms = new int[idCount];
+
+            for (int i = 0; i < idCount; i++)
+            {
+                rooms[i] = reader.ReadInt32();
+            }
+
+            int lineCount = reader.ReadInt32();
+
+            var lines = new WallGraphLineEntry[lineCount];
+
+            for (int i = 0; i < lineCount; i++)
+            {
+                lines[i] = new WallGraphLineEntry()
+                {
+                    LayerId = reader.ReadInt32(),
+                    FromId = reader.ReadInt32(),
+                    Room1 = reader.ReadInt32(),
+                    ToId = reader.ReadInt32(),
+                    Room2 = reader.ReadInt32()
+                };
+            }
+
+            return new WallGraphAsset(width, height, floors, baseFloor, pos, rooms, lines);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallGraphCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallGraphCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28692d18e26a40a4db8585b3b51be7c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using UnityEngine;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_WALLLAYER)]
+    public class WallLayerCodec : AbstractCodec
+    {
+        private const uint TypeId = 0x8a84d7b0;
+        private const int Version = 1;
+
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            var id = reader.ReadUInt32();
+            if (id != TypeId)
+            {
+                throw new ArgumentException($"WLAY has wrong id {id:x}");
+            }
+
+            // Not known if other versions exist.
+            var version = reader.ReadUInt32();
+            Debug.Assert(version == Version, "Wrong version for WLAY");
+
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "cWallLayer")
+            {
+                throw new ArgumentException($"WLAY has wrong block name {blockName}");
+            }
+
+            int count = reader.ReadInt32();
+
+            var entries = new WallLayerEntry[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                entries[i] = new WallLayerEntry()
+                {
+                    Id = reader.ReadInt32(),
+                    WallType = reader.ReadInt32(),
+                    Pattern1 = reader.ReadUInt16(),
+                    Pattern2 = reader.ReadUInt16()
+                };
+            }
+
+            return new WallLayerAsset(entries);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs
@@ -48,7 +48,7 @@ namespace OpenTS2.Files.Formats.DBPF
                 entries[i] = new WallLayerEntry()
                 {
                     Id = reader.ReadInt32(),
-                    WallType = reader.ReadInt32(),
+                    WallType = (WallType)reader.ReadInt32(),
                     Pattern1 = reader.ReadUInt16(),
                     Pattern2 = reader.ReadUInt16()
                 };

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/WallLayerCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 917947ec4da6c454a8b049064277d70a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_2DArrayCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_2DArrayCodec.cs
@@ -1,0 +1,63 @@
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using System;
+using System.IO;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    [Codec(TypeIDs.LOT_TERRAIN)]
+    public class _2DArrayCodec : AbstractCodec
+    {
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            int id = reader.ReadInt32(); // Magic?
+            int version = reader.ReadInt32(); // Version
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "c2DArray")
+            {
+                throw new NotImplementedException($"Invalid 2D Array type {blockName}");
+            }
+
+            int width = reader.ReadInt32();
+            int height = reader.ReadInt32();
+
+            // Determine the data type using the remaining stream size.
+
+            int elements = width * height;
+            int elemSize = (int)((stream.Length - stream.Position) / elements);
+
+            switch (elemSize)
+            {
+                case 1:
+                    return new _2DArrayAsset<byte>(width, height, id, ReadElements(elements, reader.ReadByte));
+                case 2:
+                    return new _2DArrayAsset<ushort>(width, height, id, ReadElements(elements, reader.ReadUInt16));
+                case 4:
+                    return new _2DArrayAsset<float>(width, height, id, ReadElements(elements, reader.ReadFloat));
+                default:
+                    throw new NotImplementedException($"Invalid 2D Array size {elemSize}");
+            }
+        }
+
+        private T[] ReadElements<T>(int elements, Func<T> reader)
+        {
+            T[] result = new T[elements];
+
+            for (int i = 0; i < elements; i++)
+            {
+                result[i] = reader();
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_2DArrayCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_2DArrayCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 763f209eb43659b4999035bedcf55922
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs
@@ -52,6 +52,13 @@ namespace OpenTS2.Files.Formats.DBPF
             // Determine the data type using the remaining stream size.
 
             int elements = width * height * depth;
+
+            // TODO: This sucks
+            if (elements == 0)
+            {
+                return new _3DArrayAsset<Vector4<ushort>>(width, height, depth, id, new Vector4<ushort>[0][]);
+            }
+
             int elemSize = (int)((stream.Length - stream.Position) / elements);
 
             Vector4<ushort> readVec4Ushort()

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs
@@ -1,0 +1,104 @@
+using OpenTS2.Common;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Utils;
+using System;
+using System.IO;
+
+namespace OpenTS2.Files.Formats.DBPF
+{
+    public struct Vector4<T> where T : unmanaged
+    {
+        public T x;
+        public T y;
+        public T z;
+        public T w;
+
+        public Vector4(T x, T y, T z, T w)
+        {
+            (this.x, this.y, this.z, this.w) = (x, y, z, w);
+        }
+        
+        public override string ToString()
+        {
+            return $"{x}";
+        }
+    }
+
+    [Codec(TypeIDs.LOT_3ARY)]
+    public class _32ArrayCodec : AbstractCodec
+    {
+        public override AbstractAsset Deserialize(byte[] bytes, ResourceKey tgi, DBPFFile sourceFile)
+        {
+            var stream = new MemoryStream(bytes);
+            var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+            // Skip 64 bytes.
+            reader.Seek(SeekOrigin.Current, 64);
+
+            int id = reader.ReadInt32(); // Magic?
+            int version = reader.ReadInt32(); // Version?
+            string blockName = reader.ReadVariableLengthPascalString();
+
+            if (blockName != "c3DArray")
+            {
+                throw new NotImplementedException($"Invalid 3D Array type {blockName}");
+            }
+
+            int width = reader.ReadInt32();
+            int height = reader.ReadInt32();
+            int depth = reader.ReadInt32();
+
+            // Determine the data type using the remaining stream size.
+
+            int elements = width * height * depth;
+            int elemSize = (int)((stream.Length - stream.Position) / elements);
+
+            Vector4<ushort> readVec4Ushort()
+            {
+                return new Vector4<ushort>(reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadUInt16(), reader.ReadUInt16());
+            }
+
+            Vector4<int> readVec4Int()
+            {
+                return new Vector4<int>(reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32(), reader.ReadInt32());
+            }
+
+            switch (elemSize)
+            {
+                case 1:
+                    return new _3DArrayAsset<byte>(width, height, depth, id, ReadElements(elements, reader.ReadByte, depth));
+                case 2:
+                    return new _3DArrayAsset<ushort>(width, height, depth, id, ReadElements(elements, reader.ReadUInt16, depth));
+                case 4:
+                    return new _3DArrayAsset<float>(width, height, depth, id, ReadElements(elements, reader.ReadFloat, depth));
+                case 8:
+                    return new _3DArrayAsset<Vector4<ushort>>(width, height, depth, id, ReadElements(elements, readVec4Ushort, depth));
+                case 16:
+                    return new _3DArrayAsset<Vector4<int>>(width, height, depth, id, ReadElements(elements, readVec4Int, depth));
+                default:
+                    throw new NotImplementedException($"Invalid 3D Array size {elemSize}");
+            }
+        }
+
+        private T[][] ReadElements<T>(int elements, Func<T> reader, int depth)
+        {
+            T[][] result = new T[depth][];
+
+            for (int i = 0; i < depth; i++)
+            {
+                int elemSlice = elements / depth;
+                T[] slice = new T[elements];
+
+                for (int j = 0; j < elemSlice; j++)
+                {
+                    slice[j] = reader();
+                }
+
+                result[i] = slice;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Formats/DBPF/_3DArrayCodec.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4caf2969b378f94db4523a921efc5b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Files/Formats/XML/PropertySet.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/XML/PropertySet.cs
@@ -30,6 +30,9 @@ namespace OpenTS2.Files.Formats.XML
 
         public PropertySet(string xml)
         {
+            // Special characters are used without proper escaping in XMLs in TS2. & needs escaped.
+            xml = xml.Replace("&", "&amp;");
+
             var parsed = XElement.Parse(xml);
             if (parsed.Name.LocalName != "cGZPropertySetString")
             {

--- a/Assets/Scripts/OpenTS2/Files/Formats/XML/PropertySet.cs
+++ b/Assets/Scripts/OpenTS2/Files/Formats/XML/PropertySet.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using OpenTS2.Files.Utils;
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
+using System.IO;
+using System.Text;
 using System.Xml.Linq;
-using UnityEngine;
 
 namespace OpenTS2.Files.Formats.XML
 {
@@ -11,6 +13,15 @@ namespace OpenTS2.Files.Formats.XML
     /// </summary>
     public class PropertySet
     {
+        private enum CPFType : uint
+        {
+            Int = 0xEB61E4F7,
+            String = 0x0B8BEA18,
+            Float = 0xABC78708,
+            Bool = 0xCBA908E1,
+            Int2 = 0x0C264712
+        }
+
         public Dictionary<string, IPropertyType> Properties { get; } = new Dictionary<string, IPropertyType>();
 
         /// <summary>
@@ -28,7 +39,58 @@ namespace OpenTS2.Files.Formats.XML
             throw new ArgumentException($"{key} is of type {Properties[key].GetType()}, not {typeof(T)}");
         }
 
+        public PropertySet(byte[] data)
+        {
+            if (data[0] == 0xe0 && data[1] == 0x50 && data[2] == 0xe7 && data[3] == 0xcb)
+            {
+                var stream = new MemoryStream(data);
+                var reader = IoBuffer.FromStream(stream, ByteOrder.LITTLE_ENDIAN);
+
+                LoadFromCPF(reader);
+            }
+            else
+            {
+                LoadFromXML(Encoding.UTF8.GetString(data));
+            }
+        }
+
         public PropertySet(string xml)
+        {
+            LoadFromXML(xml);
+        }
+
+        private void LoadFromCPF(IoBuffer reader)
+        {
+            uint type = reader.ReadUInt32();
+            short version = reader.ReadInt16();
+
+            int count = reader.ReadInt32();
+
+            for (int i = 0; i < count; i++)
+            {
+                CPFType fieldType = (CPFType)reader.ReadUInt32();
+                string key = reader.ReadUint32PrefixedString();
+
+                switch (fieldType)
+                {
+                    case CPFType.Int:
+                    case CPFType.Int2:
+                        Properties[key] = new Uint32Prop() { Value = reader.ReadUInt32() };
+                        break;
+                    case CPFType.Float:
+                        Properties[key] = new StringProp() { Value = reader.ReadSingle().ToString(CultureInfo.InvariantCulture) };
+                        break;
+                    case CPFType.Bool:
+                        Properties[key] = new Uint32Prop() { Value = reader.ReadByte() };
+                        break;
+                    case CPFType.String:
+                        Properties[key] = new StringProp() { Value = reader.ReadUint32PrefixedString() };
+                        break;
+                }
+            }
+        }
+
+        private void LoadFromXML(string xml)
         {
             // Special characters are used without proper escaping in XMLs in TS2. & needs escaped.
             xml = xml.Replace("&", "&amp;");

--- a/Assets/Scripts/OpenTS2/Files/Utils/ReinterpretCast.cs
+++ b/Assets/Scripts/OpenTS2/Files/Utils/ReinterpretCast.cs
@@ -1,0 +1,20 @@
+using Unity.Collections.LowLevel.Unsafe;
+
+namespace OpenTS2.Files.Utils
+{
+    public unsafe static class ReinterpretCast
+    {
+        public static void Copy<T1, T2>(T1[] src, T2[] dst, int bytes) where T1 : unmanaged where T2 : unmanaged
+        {
+            fixed (void* srcPtr = src, dstPtr = dst)
+            {
+                UnsafeUtility.MemCpy(dstPtr, srcPtr, bytes);
+            }
+        }
+
+        public static T2 As<T1, T2>(T1 src) where T1 : unmanaged where T2 : unmanaged
+        {
+            return *(T2*)&src;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Files/Utils/ReinterpretCast.cs.meta
+++ b/Assets/Scripts/OpenTS2/Files/Utils/ReinterpretCast.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 33a4b7c81da9a384687a4b1b82341444
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
@@ -23,6 +23,12 @@ namespace OpenTS2.Rendering
             RegisterMaterial<ImposterDualPackedSliceMaterial>();
             RegisterMaterial<ImposterRoofMaterial>();
 
+            RegisterMaterial<FloorMaterial>();
+            RegisterMaterial<FloorPoolMaterial>();
+            RegisterMaterial<WallpaperMaterial>();
+            RegisterMaterial<WallpaperBumpMaterial>();
+            RegisterMaterial<WallpaperPoolMaterial>();
+
             RegisterMaterial<TextureAlphaMaterial>();
             RegisterMaterial<VertexAlphaMaterial>();
             RegisterMaterial<PhongAlphaMaterial>();

--- a/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
@@ -23,6 +23,7 @@ namespace OpenTS2.Rendering
             RegisterMaterial<ImposterDualPackedSliceMaterial>();
             RegisterMaterial<ImposterRoofMaterial>();
 
+            RegisterMaterial<BaseTextureMaterial>();
             RegisterMaterial<FloorMaterial>();
             RegisterMaterial<FloorPoolMaterial>();
             RegisterMaterial<WallpaperMaterial>();

--- a/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/MaterialManager.cs
@@ -45,9 +45,9 @@ namespace OpenTS2.Rendering
             Batching.MarkShadersNoBatching("OpenTS2/LotImposterRoof");
         }
 
-        public static Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        public static Material Parse(ScenegraphMaterialDefinitionAsset definition, string forceType)
         {
-            if (!s_materials.TryGetValue(definition.MaterialDefinition.Type, out AbstractMaterial material))
+            if (!s_materials.TryGetValue(forceType ?? definition.MaterialDefinition.Type, out AbstractMaterial material))
                 throw new KeyNotFoundException($"Can't find material type {definition.MaterialDefinition.Type} for {definition.MaterialDefinition.MaterialName}");
             return material.Parse(definition);
         }

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/BaseTextureMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/BaseTextureMaterial.cs
@@ -1,0 +1,15 @@
+﻿using OpenTS2.Content.DBPF.Scenegraph;
+using UnityEngine;
+
+namespace OpenTS2.Rendering.Materials
+{
+    public class BaseTextureMaterial : StandardMaterial
+    {
+        public override string Name => "BaseTextureMaterial";
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            return base.Parse(definition);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/BaseTextureMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/BaseTextureMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5caa1191aea8e854baf5e991a060e758
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs
@@ -1,0 +1,28 @@
+﻿using OpenTS2.Content.DBPF.Scenegraph;
+using UnityEngine;
+
+namespace OpenTS2.Rendering.Materials
+{
+    /// <summary>
+    /// Unknown.
+    /// </summary>
+    public class FloorMaterial : StandardMaterial
+    {
+        public override string Name => "Floor";
+
+        private static readonly int UVScale = Shader.PropertyToID("_UVScale");
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            // Includes floorMaterialScaleU and floorMaterialScaleV, currently unhandled.
+            var material = base.Parse(definition);
+
+            float u = float.Parse(definition.GetProperty("floorMaterialScaleU", defaultValue: "1.0"));
+            float v = float.Parse(definition.GetProperty("floorMaterialScaleV", defaultValue: "1.0"));
+
+            material.SetVector(UVScale, new Vector4(1 / u, 1 / v, 0, 0));
+
+            return material;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs
@@ -14,7 +14,7 @@ namespace OpenTS2.Rendering.Materials
 
         public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
         {
-            // Includes floorMaterialScaleU and floorMaterialScaleV, currently unhandled.
+            // Includes floorMaterialScaleU and floorMaterialScaleV, currently included in the StandardMaterial.
             var material = base.Parse(definition);
 
             float u = float.Parse(definition.GetProperty("floorMaterialScaleU", defaultValue: "1.0"));

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/FloorMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea920c784ac954940b8a4d7abe323e51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/FloorPoolMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/FloorPoolMaterial.cs
@@ -1,0 +1,10 @@
+﻿namespace OpenTS2.Rendering.Materials
+{
+    /// <summary>
+    /// Unknown.
+    /// </summary>
+    public class FloorPoolMaterial : FloorMaterial
+    {
+        public override string Name => "FloorPool";
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/FloorPoolMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/FloorPoolMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd7080205d5002c40be7865477a74505
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
@@ -97,12 +97,7 @@ namespace OpenTS2.Rendering.Materials
                 }
             }
 
-            float alpha = alphaMul * untexturedAlpha;
-
-            if (alpha != 1)
-            {
-                material.SetFloat(AlphaMultiplier, alpha);
-            }
+            material.SetFloat(AlphaMultiplier, alphaMul * untexturedAlpha);
 
             if (bumpMapEnabled && bumpMapTexture != null)
             {

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
@@ -40,6 +40,9 @@ namespace OpenTS2.Rendering.Materials
 
             var material = new Material(shader);
             var bumpMapEnabled = false;
+            float alphaMul = 1f;
+            float untexturedAlpha = 1f;
+
             ScenegraphTextureAsset bumpMapTexture = null;
             // Adjust the material properties based on the corresponding keys.
             foreach (var property in definition.MaterialDefinition.MaterialProperties)
@@ -78,13 +81,23 @@ namespace OpenTS2.Rendering.Materials
                         material.mainTexture = texture.GetSelectedImageAsUnityTexture(ContentProvider.Get());
                         break;
                     case "stdMatAlphaMultiplier":
-                        material.SetFloat(AlphaMultiplier, float.Parse(property.Value));
+                        alphaMul = float.Parse(property.Value);
+                        break;
+                    case "stdMatUntexturedDiffAlpha":
+                        untexturedAlpha = float.Parse(property.Value);
                         break;
                     case "stdMatDiffCoef":
                         var coefficients = property.Value.Split(',').Select(float.Parse).ToArray();
                         material.SetColor(DiffuseCoefficient, new Color(coefficients[0], coefficients[1], coefficients[2]));
                         break;
                 }
+            }
+
+            float alpha = alphaMul * untexturedAlpha;
+
+            if (alpha != 1)
+            {
+                material.SetFloat(AlphaMultiplier, alpha);
             }
 
             if (bumpMapEnabled && bumpMapTexture != null)

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/StandardMaterial.cs
@@ -21,22 +21,26 @@ namespace OpenTS2.Rendering.Materials
         private static readonly int DiffuseCoefficient = Shader.PropertyToID("_DiffuseCoefficient");
         private static readonly int BumpMap = Shader.PropertyToID("_BumpMap");
 
-        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        protected virtual Shader GetShader(ScenegraphMaterialDefinitionAsset definition)
         {
-            Shader shader;
             // Decide which shader to use based on the alpha blending and alpha testing.
             if (definition.GetProperty("stdMatAlphaTestEnabled", defaultValue: "0") == "1")
             {
-                shader = Shader.Find("OpenTS2/StandardMaterial/AlphaCutOut");
+                return Shader.Find("OpenTS2/StandardMaterial/AlphaCutOut");
             }
             else if (definition.GetProperty("stdMatAlphaBlendMode", defaultValue: "none") == "blend")
             {
-                shader = Shader.Find("OpenTS2/StandardMaterial/AlphaBlended");
+                return Shader.Find("OpenTS2/StandardMaterial/AlphaBlended");
             }
             else
             {
-                shader = Shader.Find("OpenTS2/StandardMaterial/Opaque");
+                return Shader.Find("OpenTS2/StandardMaterial/Opaque");
             }
+        }
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            Shader shader = GetShader(definition);
 
             var material = new Material(shader);
             var bumpMapEnabled = false;

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs
@@ -1,20 +1,7 @@
-﻿using OpenTS2.Content.DBPF.Scenegraph;
-using UnityEngine;
-
-namespace OpenTS2.Rendering.Materials
+﻿namespace OpenTS2.Rendering.Materials
 {
-    public class WallpaperBumpMaterial : StandardMaterial
+    public class WallpaperBumpMaterial : WallpaperMaterial
     {
         public override string Name => "WallpaperBump";
-
-        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
-        {
-            // TODO: mask
-
-            definition.MaterialDefinition.MaterialProperties["stdMatAlphaTestEnabled"] = "1";
-            definition.MaterialDefinition.MaterialProperties["stdMatAlphaRefValue"] = "128";
-
-            return base.Parse(definition);
-        }
     }
 }

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs
@@ -1,0 +1,20 @@
+﻿using OpenTS2.Content.DBPF.Scenegraph;
+using UnityEngine;
+
+namespace OpenTS2.Rendering.Materials
+{
+    public class WallpaperBumpMaterial : StandardMaterial
+    {
+        public override string Name => "WallpaperBump";
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            // TODO: mask
+
+            definition.MaterialDefinition.MaterialProperties["stdMatAlphaTestEnabled"] = "1";
+            definition.MaterialDefinition.MaterialProperties["stdMatAlphaRefValue"] = "128";
+
+            return base.Parse(definition);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperBumpMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56b708a58d7273d4c8165b5c0e9fbf6c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs
@@ -1,0 +1,20 @@
+﻿using OpenTS2.Content.DBPF.Scenegraph;
+using UnityEngine;
+
+namespace OpenTS2.Rendering.Materials
+{
+    public class WallpaperMaterial : StandardMaterial
+    {
+        public override string Name => "Wallpaper";
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            // TODO: mask
+
+            definition.MaterialDefinition.MaterialProperties["stdMatAlphaTestEnabled"] = "1";
+            definition.MaterialDefinition.MaterialProperties["stdMatAlphaRefValue"] = "128";
+
+            return base.Parse(definition);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs
@@ -7,6 +7,11 @@ namespace OpenTS2.Rendering.Materials
     {
         public override string Name => "Wallpaper";
 
+        protected override Shader GetShader(ScenegraphMaterialDefinitionAsset definition)
+        {
+            return Shader.Find("OpenTS2/StandardMaterial/Wall");
+        }
+
         public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
         {
             // TODO: mask

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cacf19e96506ef74fa60d7bb3ca2dcdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs
@@ -1,0 +1,15 @@
+﻿using OpenTS2.Content.DBPF.Scenegraph;
+using UnityEngine;
+
+namespace OpenTS2.Rendering.Materials
+{
+    public class WallpaperPoolMaterial : StandardMaterial
+    {
+        public override string Name => "WallpaperPool";
+
+        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
+        {
+            return base.Parse(definition);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs
@@ -1,15 +1,7 @@
-﻿using OpenTS2.Content.DBPF.Scenegraph;
-using UnityEngine;
-
-namespace OpenTS2.Rendering.Materials
+﻿namespace OpenTS2.Rendering.Materials
 {
     public class WallpaperPoolMaterial : StandardMaterial
     {
         public override string Name => "WallpaperPool";
-
-        public override Material Parse(ScenegraphMaterialDefinitionAsset definition)
-        {
-            return base.Parse(definition);
-        }
     }
 }

--- a/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs.meta
+++ b/Assets/Scripts/OpenTS2/Rendering/Materials/WallpaperPoolMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 110041b015975a2499d322defc547fe7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 620f3615006164e48a48cd3980d76c61
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/FenceCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/FenceCollection.cs
@@ -1,0 +1,191 @@
+using OpenTS2.Common;
+using OpenTS2.Content.DBPF.Scenegraph;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Content;
+using OpenTS2.Files.Formats.DBPF;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public class FenceCollection
+    {
+        private CatalogFenceAsset _asset;
+        private GameObject _parent;
+        private bool _hasDiag;
+
+        private ScenegraphResourceAsset _railCres;
+        private ScenegraphResourceAsset _diagRailCres;
+        private ScenegraphResourceAsset _postCres;
+
+        private List<GameObject> _rails;
+        private List<GameObject> _diagRails;
+        private List<GameObject> _posts;
+
+        private bool _isVisible = true;
+
+        public FenceCollection(ContentProvider contentProvider, GameObject parent, uint guid)
+        {
+            var catalog = CatalogManager.Get();
+
+            _asset = catalog.GetFenceById(guid);
+
+            if (_asset == null)
+            {
+                return;
+            }
+
+            _hasDiag = _asset.DiagRail != null;
+            _parent = parent;
+
+            _railCres = contentProvider.GetAsset<ScenegraphResourceAsset>(
+                new ResourceKey(_asset.Rail + "_cres", GroupIDs.Scenegraph,
+                    TypeIDs.SCENEGRAPH_CRES));
+
+            _diagRailCres = _hasDiag ? contentProvider.GetAsset<ScenegraphResourceAsset>(
+                new ResourceKey(_asset.DiagRail + "_cres", GroupIDs.Scenegraph,
+                    TypeIDs.SCENEGRAPH_CRES)) : null;
+
+            _postCres = contentProvider.GetAsset<ScenegraphResourceAsset>(
+                new ResourceKey(_asset.Post + "_cres", GroupIDs.Scenegraph,
+                    TypeIDs.SCENEGRAPH_CRES));
+
+            _rails = new List<GameObject>();
+            _diagRails = new List<GameObject>();
+            _posts = new List<GameObject>();
+        }
+
+        public void AddRail(float fromX, float fromY, float toX, float toY, float fromElevation, float toElevation)
+        {
+            float direction = Mathf.Rad2Deg * Mathf.Atan2(toY - fromY, toX - fromX);
+            Vector3 shearVec = new Vector3(toX - fromX, toY - fromY, toElevation - fromElevation);
+            float magnitude = new Vector2(toX - fromX, toY - fromY).magnitude;
+            float shearMagnitude = shearVec.magnitude;
+
+            GameObject model;
+
+            if (magnitude > 1.1 && _diagRailCres != null)
+            {
+                model = _diagRailCres.CreateRootGameObject();
+
+                model.transform.parent = _parent.transform;
+
+                magnitude /= Mathf.Sqrt(2);
+
+                _diagRails.Add(model);
+            }
+            else
+            {
+                if (_railCres != null)
+                {
+                    model = _railCres.CreateRootGameObject();
+
+                    model.transform.parent = _parent.transform;
+
+                    _rails.Add(model);
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            Transform modelSpace = model.transform.GetChild(0);
+            modelSpace.localScale = new Vector3(magnitude, 1, 1);
+
+            if (shearVec.z != 0)
+            {
+                // Shear transform
+                // Because Unity doesn't support submitting your own transform matrix for some reason,
+                // We need to combine a bunch of transformations to perform a shear.
+                // In this case, we want the Z dimension to be sheared with x and y left intact.
+
+                float realAngle = Mathf.Atan2(shearVec.z, magnitude);
+                float shearAngle = realAngle > 0 ? Mathf.PI / 2 - realAngle : Mathf.PI / -2 - realAngle;
+
+                var top = new GameObject("skew_top").transform;
+                top.SetParent(model.transform);
+                var mid = new GameObject("skew_mid").transform;
+                mid.SetParent(top);
+                var bot = new GameObject("skew_bot").transform;
+                bot.SetParent(mid);
+                modelSpace.SetParent(bot);
+                modelSpace.localRotation = Quaternion.identity;
+
+                top.localRotation = Quaternion.Euler(0, -realAngle * Mathf.Rad2Deg, 0);
+                mid.localRotation = Quaternion.Euler(0, 45, 0);
+                bot.localRotation = Quaternion.Euler(0, (-shearAngle / 2) * Mathf.Rad2Deg, 0);
+
+                float initialScale = shearMagnitude;
+                float finalScale = Mathf.Sqrt(2);
+
+                top.localScale = new Vector3(finalScale / Mathf.Sin(shearAngle), 1, finalScale);
+                mid.localScale = new Vector3(Mathf.Sin(shearAngle / 2), 1, Mathf.Cos(shearAngle / 2));
+                bot.localScale = new Vector3(initialScale, 1, 1 / initialScale);
+
+                modelSpace = top;
+            }
+
+            modelSpace.localPosition = new Vector3(fromX, fromY, fromElevation);
+            modelSpace.localRotation = Quaternion.Euler(0, 0, direction) * modelSpace.localRotation;
+        }
+
+        public void AddPost(float x, float y, float elevation)
+        {
+            if (_postCres != null)
+            {
+                var model = _postCres.CreateRootGameObject();
+
+                model.transform.parent = _parent.transform;
+
+                model.transform.GetChild(0).localPosition = new Vector3(x, y, elevation);
+
+                _posts.Add(model);
+            }
+        }
+
+        public void Clear()
+        {
+            foreach (GameObject rail in _rails)
+            {
+                GameObject.Destroy(rail);
+            }
+
+            foreach (GameObject rail in _diagRails)
+            {
+                GameObject.Destroy(rail);
+            }
+
+            foreach (GameObject post in _posts)
+            {
+                GameObject.Destroy(post);
+            }
+
+            _rails.Clear();
+            _posts.Clear();
+        }
+
+        private void SetObjectVisibility(List<GameObject> objects, bool visible)
+        {
+            foreach (GameObject rail in objects)
+            {
+                foreach (MeshRenderer renderer in rail.GetComponentsInChildren<MeshRenderer>())
+                {
+                    renderer.shadowCastingMode = visible ? UnityEngine.Rendering.ShadowCastingMode.On : UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
+                }
+            }
+        }
+
+        public void SetVisible(bool visible)
+        {
+            if (_isVisible != visible)
+            {
+                _isVisible = visible;
+
+                SetObjectVisibility(_rails, visible);
+                SetObjectVisibility(_diagRails, visible);
+                SetObjectVisibility(_posts, visible);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/FenceCollection.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/FenceCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff10e797697b1844fac4b978a20d02f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitecture.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitecture.cs
@@ -1,0 +1,135 @@
+using OpenTS2.Common;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Files.Formats.DBPF;
+using OpenTS2.Scenes.Lot.Roof;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public class LotArchitecture
+    {
+        public const int WallMapInstance = 13;
+        public const int FloorMapInstance = 14;
+
+        public const int WallLayerInstance = 4;
+        public const int WallGraphAllInstance = 0x18;
+        public const int FencePostLayerInstance = 0x11;
+
+        public const int PoolInstance = 0;
+        public const int RoofInstance = 0;
+
+        public const int ArrayFloorPatternsInstance = 0;
+        public const int ArrayElevationInstance = 1;
+        public const int ArrayReservedTilesInstance = 3;
+        public const int ArrayUnknown1Instance = 9;
+        public const int ArrayUnknownRoomMap1Instance = 10;
+        public const int ArrayUnknownRoomMap2Instance = 11;
+        public const int ArrayUnknownIntInstance = 12;
+        public const int ArrayUnknownInt2Instance = 20;
+        public const int ArrayUnknownVector4ByteInstance = 21;
+        public const int ArrayUnknownExpansionMaskInstance = 27; // All 0xFF by default
+        public const int ArrayUnknownExpansionMask2Instance = 32; // All 0x11 by default
+        public const int ArrayUnknownExpansionMask3Instance = 0x5D00; // Empty or missing by default
+        public const int ArrayUnknownExpansionMask4Instance = 0x5D01; // All 0 by default, sometimes 0x0a
+        public const int ArrayUnknownExpansionMask5Instance = 0x5D02; // All 0x11 by default
+
+        public const int BlendTexturesInstance = 0;
+        public const int WaterHeightmapInstance = 15222;
+        public const int BlendMaskBaseInstance = 0x5CBC;
+        public const int TerrainUnknownInstance = 0x5CEE;
+
+        // Metadata
+        public int BaseFloor { get; private set; }
+
+        // Resource Map
+        public StringMapAsset WallMap { get; private set; }
+        public StringMapAsset FloorMap { get; private set; }
+
+        // Walls
+        public WallGraphAsset WallGraphAll { get; private set; }
+        public WallLayerAsset WallLayer { get; private set; }
+        public FencePostLayerAsset FencePostLayer { get; private set; }
+
+        // 3D Arrays
+        public _3DArrayView<Vector4<ushort>> FloorPatterns { get; private set; }
+        public _3DArrayView<float> Elevation { get; private set; }
+
+        public RoofAsset RoofAsset { get; private set; }
+        public RoofCollection Roof { get; private set; }
+        public PoolAsset Pool { get; private set; }
+
+        // Terrain
+        public LotTexturesAsset BlendTextures { get; private set; }
+        public _2DArrayView<float> WaterHeightmap { get; private set; }
+        public _2DArrayView<byte>[] BlendMasks { get; private set; }
+
+
+        public void LoadFromPackage(DBPFFile lotPackage)
+        {
+            // TODO: Failsafes when assets do not exist.
+
+            WallMap = lotPackage.GetAssetByTGI<StringMapAsset>(new ResourceKey(WallMapInstance, uint.MaxValue, TypeIDs.LOT_STRINGMAP));
+            FloorMap = lotPackage.GetAssetByTGI<StringMapAsset>(new ResourceKey(FloorMapInstance, uint.MaxValue, TypeIDs.LOT_STRINGMAP));
+
+            /*
+             * There are a bunch of these that aren't used yet.
+            var wallGraphs = lotPackage.Entries.Where(x => x.GlobalTGI.TypeID == TypeIDs.LOT_WALLGRAPH).Select(x => x.GetAsset<WallGraphAsset>()).ToList();
+            var arry3 = lotPackage.Entries.Where(x => x.GlobalTGI.TypeID == TypeIDs.LOT_3ARY).Select(x => x.GetAsset()).ToList();
+            */
+
+            // Shared
+
+            WallGraphAll = lotPackage.GetAssetByTGI<WallGraphAsset>(new ResourceKey(WallGraphAllInstance, uint.MaxValue, TypeIDs.LOT_WALLGRAPH));
+            WallLayer = lotPackage.GetAssetByTGI<WallLayerAsset>(new ResourceKey(WallLayerInstance, uint.MaxValue, TypeIDs.LOT_WALLLAYER));
+            FencePostLayer = lotPackage.GetAssetByTGI<FencePostLayerAsset>(new ResourceKey(FencePostLayerInstance, uint.MaxValue, TypeIDs.LOT_FENCEPOST));
+
+            FloorPatterns = lotPackage.GetAssetByTGI<_3DArrayAsset>(new ResourceKey(ArrayFloorPatternsInstance, uint.MaxValue, TypeIDs.LOT_3ARY)).GetView<Vector4<ushort>>(true);
+            Elevation = lotPackage.GetAssetByTGI<_3DArrayAsset>(new ResourceKey(ArrayElevationInstance, uint.MaxValue, TypeIDs.LOT_3ARY)).GetView<float>(true);
+
+            Pool = lotPackage.GetAssetByTGI<PoolAsset>(new ResourceKey(PoolInstance, uint.MaxValue, TypeIDs.LOT_POOL));
+            RoofAsset = lotPackage.GetAssetByTGI<RoofAsset>(new ResourceKey(RoofInstance, uint.MaxValue, TypeIDs.LOT_ROOF));
+
+            BaseFloor = WallGraphAll.BaseFloor;
+
+            Roof = new RoofCollection(RoofAsset.Entries, Elevation, BaseFloor);
+
+            // Terrain
+
+            BlendTextures = lotPackage.GetAssetByTGI<LotTexturesAsset>(new ResourceKey(BlendTexturesInstance, uint.MaxValue, TypeIDs.LOT_TEXTURES));
+            WaterHeightmap = lotPackage.GetAssetByTGI<_2DArrayAsset>(new ResourceKey(WaterHeightmapInstance, uint.MaxValue, TypeIDs.LOT_TERRAIN)).GetView<float>(true);
+
+            int textureCount = BlendTextures.BlendTextures.Length;
+            BlendMasks = new _2DArrayView<byte>[textureCount];
+
+            for (int i = 0; i < textureCount; i++)
+            {
+                BlendMasks[i] = lotPackage.GetAssetByTGI<_2DArrayAsset>(new ResourceKey((uint)(BlendMaskBaseInstance + i), uint.MaxValue, TypeIDs.LOT_TERRAIN)).GetView<byte>(true);
+            }
+        }
+
+        /// <summary>
+        /// Creates game objects for the lot architecture, and returns them in the provided list.
+        /// </summary>
+        /// <param name="componentList">List of created game objects</param>
+        public void CreateGameObjects(List<GameObject> componentList)
+        {
+            var roofObj = new GameObject("roof", typeof(LotRoofComponent));
+            roofObj.GetComponent<LotRoofComponent>().CreateFromLotAssets(RoofAsset.Entries.FirstOrDefault().Pattern, Roof);
+            componentList.Add(roofObj);
+
+            var wall = new GameObject("wall", typeof(LotWallComponent));
+            wall.GetComponent<LotWallComponent>().CreateFromLotAssets(WallMap, WallLayer, WallGraphAll, FencePostLayer, Elevation, Roof);
+            componentList.Add(wall);
+
+            var floor = new GameObject("floor", typeof(LotFloorComponent));
+            floor.GetComponent<LotFloorComponent>().CreateFromLotAssets(FloorMap, FloorPatterns, Elevation, BaseFloor);
+            componentList.Add(floor);
+
+            var terrain = new GameObject("terrain", typeof(LotTerrainComponent));
+            terrain.GetComponent<LotTerrainComponent>().CreateFromTerrainAssets(BlendTextures, Elevation, BlendMasks, WaterHeightmap, FloorPatterns, BaseFloor);
+            componentList.Add(terrain);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitecture.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitecture.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ac52f81a46429f4198a750b861d115e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
@@ -2,7 +2,6 @@ using OpenTS2.Components;
 using System.Collections.Generic;
 using UnityEngine;
 
-
 namespace OpenTS2.Scenes.Lot
 {
     [RequireComponent(typeof(MeshFilter))]
@@ -16,6 +15,10 @@ namespace OpenTS2.Scenes.Lot
         private List<Vector2> _vertexUvBuilder = new List<Vector2>();
         private List<int> _indexBuilder = new List<int>();
 
+        private MeshRenderer _renderer;
+        private bool _enableShadows = true;
+        private bool _visible = true;
+
         public void Initialize(Material material)
         {
             Mesh = new Mesh();
@@ -23,9 +26,14 @@ namespace OpenTS2.Scenes.Lot
 
             GetComponent<MeshFilter>().sharedMesh = Mesh;
 
-            var meshRenderer = GetComponent<MeshRenderer>();
+            _renderer = GetComponent<MeshRenderer>();
 
-            meshRenderer.sharedMaterial = material;
+            _renderer.sharedMaterial = material;
+        }
+
+        public void EnableExtraUV()
+        {
+
         }
 
         public int GetVertexIndex()
@@ -80,12 +88,44 @@ namespace OpenTS2.Scenes.Lot
 
         public void EnableShadows(bool enable)
         {
-            var meshRenderer = GetComponent<MeshRenderer>();
+            _enableShadows = enable;
 
-            meshRenderer.shadowCastingMode = enable ? UnityEngine.Rendering.ShadowCastingMode.On : UnityEngine.Rendering.ShadowCastingMode.Off;
+            UpdateVisibility(true);
         }
 
-        public void Commit()
+        private void UpdateVisibility(bool shadowChange)
+        {
+            if (_enableShadows)
+            {
+                if (shadowChange)
+                {
+                    _renderer.enabled = true;
+                }
+
+                _renderer.shadowCastingMode = _visible ? UnityEngine.Rendering.ShadowCastingMode.On : UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
+            }
+            else
+            {
+                if (shadowChange)
+                {
+                    _renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                }
+
+                _renderer.enabled = _visible;
+            }
+        }
+
+        public void SetVisible(bool visible)
+        {
+            if (visible != _visible)
+            {
+                _visible = visible;
+
+                UpdateVisibility(false);
+            }
+        }
+
+        public bool Commit()
         {
             if (_vertexBuilder.Count > 65536 && Mesh.indexFormat == UnityEngine.Rendering.IndexFormat.UInt16)
             {
@@ -99,6 +139,8 @@ namespace OpenTS2.Scenes.Lot
             Mesh.RecalculateNormals();
             Mesh.RecalculateTangents();
             Mesh.RecalculateBounds();
+
+            return _vertexBuilder.Count > 0 || _indexBuilder.Count > 0;
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
@@ -68,25 +68,6 @@ namespace OpenTS2.Scenes.Lot
             _indexBuilder.Add(baseVertex + c);
         }
 
-        public void AddWindingRect(int baseVert)
-        {
-            _indexBuilder.Add(baseVert);
-            _indexBuilder.Add(baseVert + 1);
-            _indexBuilder.Add(baseVert + 4);
-
-            _indexBuilder.Add(baseVert + 1);
-            _indexBuilder.Add(baseVert + 2);
-            _indexBuilder.Add(baseVert + 4);
-
-            _indexBuilder.Add(baseVert + 2);
-            _indexBuilder.Add(baseVert + 3);
-            _indexBuilder.Add(baseVert + 4);
-
-            _indexBuilder.Add(baseVert + 3);
-            _indexBuilder.Add(baseVert);
-            _indexBuilder.Add(baseVert + 4);
-        }
-
         public void Clear()
         {
             _vertexBuilder.Clear();

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
@@ -13,6 +13,7 @@ namespace OpenTS2.Scenes.Lot
 
         private List<Vector3> _vertexBuilder = new List<Vector3>();
         private List<Vector2> _vertexUvBuilder = new List<Vector2>();
+        private List<Vector2> _vertexUv2Builder;
         private List<int> _indexBuilder = new List<int>();
 
         private MeshRenderer _renderer;
@@ -33,7 +34,7 @@ namespace OpenTS2.Scenes.Lot
 
         public void EnableExtraUV()
         {
-
+            _vertexUv2Builder ??= new List<Vector2>();
         }
 
         public int GetVertexIndex()
@@ -51,6 +52,13 @@ namespace OpenTS2.Scenes.Lot
         {
             _vertexBuilder.AddRange(vertices);
             _vertexUvBuilder.AddRange(uvs);
+        }
+
+        public void AddVertices(Vector3[] vertices, Vector2[] uvs, Vector2[] uvs2)
+        {
+            _vertexBuilder.AddRange(vertices);
+            _vertexUvBuilder.AddRange(uvs);
+            _vertexUv2Builder.AddRange(uvs2);
         }
 
         public void AddTriangle(int baseVertex, int a, int b, int c)
@@ -134,6 +142,10 @@ namespace OpenTS2.Scenes.Lot
 
             Mesh.SetVertices(_vertexBuilder);
             Mesh.SetUVs(0, _vertexUvBuilder);
+            if (_vertexUv2Builder != null)
+            {
+                Mesh.SetUVs(1, _vertexUv2Builder);
+            }
             Mesh.SetIndices(_indexBuilder, MeshTopology.Triangles, 0);
 
             Mesh.RecalculateNormals();

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs
@@ -7,7 +7,7 @@ namespace OpenTS2.Scenes.Lot
 {
     [RequireComponent(typeof(MeshFilter))]
     [RequireComponent(typeof(MeshRenderer))]
-    public class LotFloorPatternComponent : AssetReferenceComponent
+    public class LotArchitectureMeshComponent : AssetReferenceComponent
     {
         public Mesh Mesh;
         public Material Material;
@@ -76,6 +76,13 @@ namespace OpenTS2.Scenes.Lot
             _vertexBuilder.Clear();
             _vertexUvBuilder.Clear();
             _indexBuilder.Clear();
+        }
+
+        public void EnableShadows(bool enable)
+        {
+            var meshRenderer = GetComponent<MeshRenderer>();
+
+            meshRenderer.shadowCastingMode = enable ? UnityEngine.Rendering.ShadowCastingMode.On : UnityEngine.Rendering.ShadowCastingMode.Off;
         }
 
         public void Commit()

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotArchitectureMeshComponent.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b62510fe6e902374cb0d1a7d1a121e25
+guid: c38306fe2f4ee23499ce5dd83628a2fd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -1,0 +1,396 @@
+using OpenTS2.Common;
+using OpenTS2.Components;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Content.DBPF.Scenegraph;
+using OpenTS2.Files.Formats.DBPF;
+using OpenTS2.Files.Formats.DBPF.Scenegraph;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public class LotFloorComponent : AssetReferenceComponent
+    {
+        private const string ThicknessTexture = "floor-edge";
+        private const string FallbackMaterial = "floor-grid";
+        private const float Thickness = 0.1f;
+
+        private class PatternMesh
+        {
+            public GameObject Object;
+            public LotFloorPatternComponent Component;
+
+            public PatternMesh(GameObject parent, string name, Material material)
+            {
+                Object = new GameObject(name, typeof(LotFloorPatternComponent));
+                Component = Object.GetComponent<LotFloorPatternComponent>();
+
+                Object.transform.SetParent(parent.transform);
+                Component.Initialize(material);
+            }
+        }
+
+        private StringMapAsset _patternMap;
+        private _3DArrayAsset<float> _elevationData;
+        private _3DArrayAsset<Vector4<ushort>> _patternData;
+        private int _baseLevel;
+
+        private PatternMesh _thickness;
+        private PatternMesh[] _patterns;
+
+        public void CreateFromLotAssets(StringMapAsset patternMap, _3DArrayAsset<Vector4<ushort>> patternData, _3DArrayAsset<float> elevationData, int baseLevel)
+        {
+            _patternMap = patternMap;
+            _patternData = patternData;
+            _elevationData = elevationData;
+            _baseLevel = baseLevel;
+
+            if (patternData.Width != elevationData.Width - 1 || patternData.Height != elevationData.Height - 1 || patternData.Depth != elevationData.Depth)
+            {
+                throw new InvalidOperationException("Size mismatch between heightmap and LTTX");
+            }
+
+            LoadPatterns();
+            BuildFloorMeshes();
+        }
+
+        private ScenegraphMaterialDefinitionAsset GenerateMaterial(string textureName)
+        {
+            var persistType = new PersistTypeInfo("cSGResource", 0, 2);
+
+            var mat = new ScenegraphMaterialDefinitionAsset(
+                new MaterialDefinitionBlock(persistType,
+                    new ScenegraphResource(),
+                    textureName,
+                    "Floor",
+                    new Dictionary<string, string>()
+                    {
+                        { "deprecatedStdMatInvDiffuseCoeffMultiplier", "1.2" },
+                        { "floorMaterialScaleU", "1.000000" },
+                        { "floorMaterialScaleV", "1.000000" },
+                        { "reflectivity", "0.5" },
+                        { "stdMatBaseTextureAddressingU", "tile" },
+                        { "stdMatBaseTextureAddressingV", "tile" },
+                        { "stdMatBaseTextureEnabled", "true" },
+                        { "stdMatBaseTextureName", textureName },
+                        { "stdMatDiffCoef", "0.8,0.8,0.8,1" },
+                        { "stdMatEmissiveCoef", "0,0,0" },
+                        { "stdMatEnvCubeCoef", "0,0,0,0,0" },
+                        { "stdMatLayer", "0" },
+                        { "stdMatSpecCoef", "0,0,0" },
+                        { "stdMatUntexturedDiffAlpha", "1" }
+                    },
+                    new string[] { textureName }
+                )
+            );
+
+            mat.TGI = new ResourceKey(textureName + "_txmt", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXTR);
+
+            AddReference(mat);
+
+            return mat;
+        }
+
+        private ScenegraphMaterialDefinitionAsset LoadMaterial(ContentProvider contentProvider, string name)
+        {
+            var material = contentProvider.GetAsset<ScenegraphMaterialDefinitionAsset>(new ResourceKey($"{name}_txmt", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXMT));
+
+            AddReference(material);
+
+            return material;
+        }
+
+        private void LoadPatterns()
+        {
+            // Load the patterns. Some references are by asset name (do not exist in catalog), others are by catalog GUID.
+
+            var contentProvider = ContentProvider.Get();
+            var catalogManager = CatalogManager.Get();
+
+            ushort highestId = _patternMap.Map.Keys.Max();
+            _patterns = new PatternMesh[highestId + 1];
+
+            foreach (StringMapEntry entry in _patternMap.Map.Values)
+            {
+                string materialName;
+                if (uint.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint guid))
+                {
+                    var catalogEntry = catalogManager.GetEntryById(guid);
+
+                    materialName = catalogEntry?.Material ?? FallbackMaterial;
+                }
+                else
+                {
+                    materialName = entry.Value.StartsWith("floor_") ? entry.Value : ("floor_" + entry.Value);
+                }
+
+                // Try fetch the texture using the material name.
+
+                var material = LoadMaterial(contentProvider, materialName);
+
+                if (material == null)
+                {
+
+                }
+
+                _patterns[entry.Id] = material == null ? null : new PatternMesh(gameObject, materialName, material?.GetAsUnityMaterial());
+            }
+
+            _thickness = new PatternMesh(gameObject, ThicknessTexture, GenerateMaterial(ThicknessTexture).GetAsUnityMaterial());
+        }
+
+        private void BuildFloorMeshes()
+        {
+            // TODO: split pattern meshes by level?
+            int width = _patternData.Width;
+            int height = _patternData.Height;
+            int eHeight = height + 1;
+
+            foreach (PatternMesh pattern in _patterns)
+            {
+                pattern?.Component.Clear();
+            }
+
+            Vector3[] tileVertices = new Vector3[5];
+            Vector2[] tileUVs = new Vector2[5];
+
+            Vector3[] thicknessVertices = new Vector3[4];
+            Vector2[] thicknessUVs = new Vector2[4];
+
+            var thickComp = _thickness.Component;
+
+            void AddThickness(int from, int to)
+            {
+                Vector3 fromV = tileVertices[from];
+                Vector3 toV = tileVertices[to];
+
+                int baseVert = thickComp.GetVertexIndex();
+
+                thickComp.AddVertex(fromV, new Vector2(0, 1));
+                thickComp.AddVertex(toV, new Vector2(1, 1));
+
+                fromV.y -= Thickness;
+                toV.y -= Thickness;
+
+                thickComp.AddVertex(toV, new Vector2(1, 0));
+                thickComp.AddVertex(fromV, new Vector2(0, 0));
+
+                thickComp.AddIndex(baseVert);
+                thickComp.AddIndex(baseVert + 1);
+                thickComp.AddIndex(baseVert + 2);
+
+                thickComp.AddIndex(baseVert + 2);
+                thickComp.AddIndex(baseVert + 3);
+                thickComp.AddIndex(baseVert);
+            }
+
+            for (int i = 0; i < _patternData.Depth; i++)
+            {
+                Vector4<ushort>[] patterns = _patternData.Data[i];
+                float[] elevation = _elevationData.Data[i];
+
+                // NOTE: 3D arrays are width then height, rather than height then width.
+
+                int pi = 0;
+                int ei = 0;
+
+                float fx = 0;
+
+                for (int x = 0; x < width; x++, fx++)
+                {
+                    float fy = 0;
+
+                    for (int y = 0; y < height; y++, fy++, ei++, pi++)
+                    {
+                        ref Vector4<ushort> p = ref patterns[pi];
+
+                        int filledMask = (p.w != 0 ? 1 : 0) | (p.z != 0 ? 2 : 0) | (p.y != 0 ? 4 : 0) | (p.x != 0 ? 8 : 0);
+
+                        if (filledMask != 0)
+                        {
+                            // Pattern is present.
+                            float e0 = elevation[ei];
+                            float e1 = elevation[ei + 1];
+                            float e2 = elevation[ei + eHeight + 1];
+                            float e3 = elevation[ei + eHeight];
+
+                            tileVertices[0] = new Vector3(fx, e0, fy);
+                            tileVertices[1] = new Vector3(fx + 1, e1, fy);
+                            tileVertices[2] = new Vector3(fx + 1, e2, fy + 1);
+                            tileVertices[3] = new Vector3(fx, e3, fy + 1);
+                            tileVertices[4] = new Vector3(fx + 0.5f, (e0 + e1 + e2 + e3) / 4, fy + 0.5f);
+
+                            tileUVs[0] = new Vector2(fy, fx);
+                            tileUVs[1] = new Vector2(fy, fx + 1);
+                            tileUVs[2] = new Vector2(fy + 1, fx + 1);
+                            tileUVs[3] = new Vector2(fy + 1, fx);
+                            tileUVs[4] = new Vector2(fy + 0.5f, fx + 0.5f);
+
+                            PatternMesh mesh1 = _patterns[p.w];
+                            int m1Base = 0;
+
+                            if (mesh1 != null)
+                            {
+                                var comp = mesh1.Component;
+                                m1Base = comp.GetVertexIndex();
+
+                                comp.AddVertices(tileVertices, tileUVs);
+
+                                comp.AddIndex(m1Base + 1);
+                                comp.AddIndex(m1Base);
+                                comp.AddIndex(m1Base + 4);
+                            }
+
+                            PatternMesh mesh2 = _patterns[p.z];
+                            int m2Base = 0;
+
+                            if (mesh2 != null)
+                            {
+                                var comp = mesh2.Component;
+
+                                if (mesh1 == mesh2)
+                                {
+                                    m2Base = m1Base;
+                                }
+                                else
+                                {
+                                    m2Base = comp.GetVertexIndex();
+                                    comp.AddVertices(tileVertices, tileUVs);
+                                }
+
+                                comp.AddIndex(m2Base + 2);
+                                comp.AddIndex(m2Base + 1);
+                                comp.AddIndex(m2Base + 4);
+                            }
+
+                            PatternMesh mesh3 = _patterns[p.y];
+                            int m3Base = 0;
+
+                            if (mesh3 != null)
+                            {
+                                var comp = mesh3.Component;
+
+                                if (mesh3 == mesh2)
+                                {
+                                    m3Base = m2Base;
+                                }
+                                else if (mesh3 == mesh1)
+                                {
+                                    m3Base = m1Base;
+                                }
+                                else
+                                {
+                                    m3Base = comp.GetVertexIndex();
+                                    comp.AddVertices(tileVertices, tileUVs);
+                                }
+
+                                comp.AddIndex(m3Base + 3);
+                                comp.AddIndex(m3Base + 2);
+                                comp.AddIndex(m3Base + 4);
+                            }
+
+                            PatternMesh mesh4 = _patterns[p.x];
+
+                            if (mesh4 != null)
+                            {
+                                int m4Base;
+                                var comp = mesh4.Component;
+
+                                if (mesh4 == mesh3)
+                                {
+                                    m4Base = m3Base;
+                                }
+                                else if (mesh4 == mesh2)
+                                {
+                                    m4Base = m2Base;
+                                }
+                                else if (mesh4 == mesh1)
+                                {
+                                    m4Base = m1Base;
+                                }
+                                else
+                                {
+                                    m4Base = comp.GetVertexIndex();
+                                    comp.AddVertices(tileVertices, tileUVs);
+                                }
+
+                                comp.AddIndex(m4Base);
+                                comp.AddIndex(m4Base + 3);
+                                comp.AddIndex(m4Base + 4);
+                            }
+
+                            if (i > -_baseLevel)
+                            {
+                                if (filledMask != 15)
+                                {
+                                    // Missing faces, need to add thickness for diagonals.
+
+                                    for (int tri = 0; tri < 4; tri++)
+                                    {
+                                        int bit = 1 << tri;
+
+                                        if ((filledMask & bit) != 0)
+                                        {
+                                            int next = 1 << ((tri + 1) & 3);
+                                            int prev = 1 << ((tri + 3) & 3);
+
+                                            if ((filledMask & next) == 0)
+                                            {
+                                                AddThickness((tri + 1) & 3, 4);
+                                            }
+
+                                            if ((filledMask & prev) == 0)
+                                            {
+                                                AddThickness(4, tri & 3);
+                                            }
+                                        }
+                                    }
+                                }
+
+                                // Finally, consider adding thickness for surrounding tiles.
+
+                                if (y > 0 && ((filledMask & 1) != 0) && patterns[pi - 1].y == 0)
+                                {
+                                    AddThickness(0, 1);
+                                }
+
+                                if (x < (width - 1) && ((filledMask & 2) != 0) && patterns[pi + height].x == 0)
+                                {
+                                    AddThickness(1, 2);
+                                }
+
+                                if (y < (height - 1) && ((filledMask & 4) != 0) && patterns[pi + 1].w == 0)
+                                {
+                                    AddThickness(2, 3);
+                                }
+
+                                if (x > 0 && ((filledMask & 8) != 0) && patterns[pi - height].z == 0)
+                                {
+                                    AddThickness(3, 0);
+                                }
+                            }
+                        }
+                    }
+
+                    // Elevation has an extra entry per line.
+                    ei++;
+                }
+            }
+
+            foreach (PatternMesh pattern in _patterns)
+            {
+                pattern?.Component.Commit();
+            }
+
+            _thickness.Component.Commit();
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -123,7 +123,7 @@ namespace OpenTS2.Scenes.Lot
                 GenerateMaterial(ThicknessTexture).GetAsUnityMaterial()
             );
 
-            _patterns = new PatternMeshCollection(gameObject, patterns, Array.Empty<PatternVariant>(), _architecture.FloorPatterns.Depth);
+            _patterns = new PatternMeshCollection(gameObject, patterns, Array.Empty<PatternVariant>(), null, _architecture.FloorPatterns.Depth);
         }
 
         private void BuildFloorMeshes()

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -23,21 +23,6 @@ namespace OpenTS2.Scenes.Lot
         private const string FallbackMaterial = "floor-grid";
         private const float Thickness = 0.1f;
 
-        private class PatternMesh
-        {
-            public GameObject Object;
-            public LotFloorPatternComponent Component;
-
-            public PatternMesh(GameObject parent, string name, Material material)
-            {
-                Object = new GameObject(name, typeof(LotFloorPatternComponent));
-                Component = Object.GetComponent<LotFloorPatternComponent>();
-
-                Object.transform.SetParent(parent.transform);
-                Component.Initialize(material);
-            }
-        }
-
         private StringMapAsset _patternMap;
         private _3DArrayAsset<float> _elevationData;
         private _3DArrayAsset<Vector4<ushort>> _patternData;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -100,7 +100,7 @@ namespace OpenTS2.Scenes.Lot
             var contentProvider = ContentProvider.Get();
             var catalogManager = CatalogManager.Get();
 
-            ushort highestId = _patternMap.Map.Keys.Max();
+            ushort highestId = _patternMap.Map.Count == 0 ? (ushort)0 : _patternMap.Map.Keys.Max();
             _patterns = new PatternMesh[highestId + 1];
 
             foreach (StringMapEntry entry in _patternMap.Map.Values)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -21,7 +21,7 @@ namespace OpenTS2.Scenes.Lot
     {
         private const string ThicknessTexture = "floor-edge";
         private const string FallbackMaterial = "floor-grid";
-        private const float Thickness = 0.15f;
+        public const float Thickness = 0.15f;
 
         private StringMapAsset _patternMap;
         private _3DArrayAsset<float> _elevationData;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -21,7 +21,7 @@ namespace OpenTS2.Scenes.Lot
     {
         private const string ThicknessTexture = "floor-edge";
         private const string FallbackMaterial = "floor-grid";
-        private const float Thickness = 0.1f;
+        private const float Thickness = 0.15f;
 
         private StringMapAsset _patternMap;
         private _3DArrayAsset<float> _elevationData;
@@ -168,13 +168,8 @@ namespace OpenTS2.Scenes.Lot
                 thickComp.AddVertex(toV, new Vector2(1, 0));
                 thickComp.AddVertex(fromV, new Vector2(0, 0));
 
-                thickComp.AddIndex(baseVert);
-                thickComp.AddIndex(baseVert + 1);
-                thickComp.AddIndex(baseVert + 2);
-
-                thickComp.AddIndex(baseVert + 2);
-                thickComp.AddIndex(baseVert + 3);
-                thickComp.AddIndex(baseVert);
+                thickComp.AddTriangle(baseVert, 0, 1, 2);
+                thickComp.AddTriangle(baseVert, 2, 3, 0);
             }
 
             for (int i = 0; i < _patternData.Depth; i++)
@@ -228,10 +223,7 @@ namespace OpenTS2.Scenes.Lot
                                 m1Base = comp.GetVertexIndex();
 
                                 comp.AddVertices(tileVertices, tileUVs);
-
-                                comp.AddIndex(m1Base + 1);
-                                comp.AddIndex(m1Base);
-                                comp.AddIndex(m1Base + 4);
+                                comp.AddTriangle(m1Base, 1, 0, 4);
                             }
 
                             PatternMesh mesh2 = _patterns[p.z];
@@ -251,9 +243,7 @@ namespace OpenTS2.Scenes.Lot
                                     comp.AddVertices(tileVertices, tileUVs);
                                 }
 
-                                comp.AddIndex(m2Base + 2);
-                                comp.AddIndex(m2Base + 1);
-                                comp.AddIndex(m2Base + 4);
+                                comp.AddTriangle(m2Base, 2, 1, 4);
                             }
 
                             PatternMesh mesh3 = _patterns[p.y];
@@ -277,9 +267,7 @@ namespace OpenTS2.Scenes.Lot
                                     comp.AddVertices(tileVertices, tileUVs);
                                 }
 
-                                comp.AddIndex(m3Base + 3);
-                                comp.AddIndex(m3Base + 2);
-                                comp.AddIndex(m3Base + 4);
+                                comp.AddTriangle(m3Base, 3, 2, 4);
                             }
 
                             PatternMesh mesh4 = _patterns[p.x];
@@ -307,9 +295,7 @@ namespace OpenTS2.Scenes.Lot
                                     comp.AddVertices(tileVertices, tileUVs);
                                 }
 
-                                comp.AddIndex(m4Base);
-                                comp.AddIndex(m4Base + 3);
-                                comp.AddIndex(m4Base + 4);
+                                comp.AddTriangle(m4Base, 0, 3, 4);
                             }
 
                             if (i > -_baseLevel)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -24,14 +24,14 @@ namespace OpenTS2.Scenes.Lot
         public const float Thickness = 0.15f;
 
         private StringMapAsset _patternMap;
-        private _3DArrayAsset<float> _elevationData;
-        private _3DArrayAsset<Vector4<ushort>> _patternData;
+        private _3DArrayView<float> _elevationData;
+        private _3DArrayView<Vector4<ushort>> _patternData;
         private int _baseLevel;
 
         private PatternMesh _thickness;
         private PatternMesh[] _patterns;
 
-        public void CreateFromLotAssets(StringMapAsset patternMap, _3DArrayAsset<Vector4<ushort>> patternData, _3DArrayAsset<float> elevationData, int baseLevel)
+        public void CreateFromLotAssets(StringMapAsset patternMap, _3DArrayView<Vector4<ushort>> patternData, _3DArrayView<float> elevationData, int baseLevel)
         {
             _patternMap = patternMap;
             _patternData = patternData;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs
@@ -218,9 +218,9 @@ namespace OpenTS2.Scenes.Lot
                         {
                             // Pattern is present.
                             float e0 = elevation[ei];
-                            float e1 = elevation[ei + 1];
+                            float e1 = elevation[ei + eHeight];
                             float e2 = elevation[ei + eHeight + 1];
-                            float e3 = elevation[ei + eHeight];
+                            float e3 = elevation[ei + 1];
 
                             tileVertices[0] = new Vector3(fx, e0, fy);
                             tileVertices[1] = new Vector3(fx + 1, e1, fy);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0181afa8351411d458eb52aeb921654d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
@@ -52,11 +52,6 @@ namespace OpenTS2.Scenes.Lot
             _indexBuilder.Add(baseVertex + c);
         }
 
-        public void AddIndex(int index)
-        {
-            _indexBuilder.Add(index);
-        }
-
         public void AddWindingRect(int baseVert)
         {
             _indexBuilder.Add(baseVert);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
@@ -45,6 +45,13 @@ namespace OpenTS2.Scenes.Lot
             _vertexUvBuilder.AddRange(uvs);
         }
 
+        public void AddTriangle(int baseVertex, int a, int b, int c)
+        {
+            _indexBuilder.Add(baseVertex + a);
+            _indexBuilder.Add(baseVertex + b);
+            _indexBuilder.Add(baseVertex + c);
+        }
+
         public void AddIndex(int index)
         {
             _indexBuilder.Add(index);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
@@ -85,6 +85,11 @@ namespace OpenTS2.Scenes.Lot
 
         public void Commit()
         {
+            if (_vertexBuilder.Count > 65536 && Mesh.indexFormat == UnityEngine.Rendering.IndexFormat.UInt16)
+            {
+                Mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            }
+
             Mesh.SetVertices(_vertexBuilder);
             Mesh.SetUVs(0, _vertexUvBuilder);
             Mesh.SetIndices(_indexBuilder, MeshTopology.Triangles, 0);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs
@@ -1,0 +1,90 @@
+using OpenTS2.Components;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+namespace OpenTS2.Scenes.Lot
+{
+    [RequireComponent(typeof(MeshFilter))]
+    [RequireComponent(typeof(MeshRenderer))]
+    public class LotFloorPatternComponent : AssetReferenceComponent
+    {
+        public Mesh Mesh;
+        public Material Material;
+
+        private List<Vector3> _vertexBuilder = new List<Vector3>();
+        private List<Vector2> _vertexUvBuilder = new List<Vector2>();
+        private List<int> _indexBuilder = new List<int>();
+
+        public void Initialize(Material material)
+        {
+            Mesh = new Mesh();
+            Material = material;
+
+            GetComponent<MeshFilter>().sharedMesh = Mesh;
+
+            var meshRenderer = GetComponent<MeshRenderer>();
+
+            meshRenderer.sharedMaterial = material;
+        }
+
+        public int GetVertexIndex()
+        {
+            return _vertexBuilder.Count;
+        }
+
+        public void AddVertex(Vector3 vert, Vector2 uv)
+        {
+            _vertexBuilder.Add(vert);
+            _vertexUvBuilder.Add(uv);
+        }
+
+        public void AddVertices(Vector3[] vertices, Vector2[] uvs)
+        {
+            _vertexBuilder.AddRange(vertices);
+            _vertexUvBuilder.AddRange(uvs);
+        }
+
+        public void AddIndex(int index)
+        {
+            _indexBuilder.Add(index);
+        }
+
+        public void AddWindingRect(int baseVert)
+        {
+            _indexBuilder.Add(baseVert);
+            _indexBuilder.Add(baseVert + 1);
+            _indexBuilder.Add(baseVert + 4);
+
+            _indexBuilder.Add(baseVert + 1);
+            _indexBuilder.Add(baseVert + 2);
+            _indexBuilder.Add(baseVert + 4);
+
+            _indexBuilder.Add(baseVert + 2);
+            _indexBuilder.Add(baseVert + 3);
+            _indexBuilder.Add(baseVert + 4);
+
+            _indexBuilder.Add(baseVert + 3);
+            _indexBuilder.Add(baseVert);
+            _indexBuilder.Add(baseVert + 4);
+        }
+
+        public void Clear()
+        {
+            _vertexBuilder.Clear();
+            _vertexUvBuilder.Clear();
+            _indexBuilder.Clear();
+        }
+
+        public void Commit()
+        {
+            Mesh.SetVertices(_vertexBuilder);
+            Mesh.SetUVs(0, _vertexUvBuilder);
+            Mesh.SetIndices(_indexBuilder, MeshTopology.Triangles, 0);
+
+            Mesh.RecalculateNormals();
+            Mesh.RecalculateTangents();
+            Mesh.RecalculateBounds();
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotFloorPatternComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b62510fe6e902374cb0d1a7d1a121e25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
@@ -13,21 +13,14 @@ namespace OpenTS2.Scenes.Lot
 {
     public class LotRoofComponent : AssetReferenceComponent
     {
-        private const uint DefaultGUID = 0x0cdcc049;
-
-        private RoofCollection _roofs;
+        private LotArchitecture _architecture;
         private RoofGeometryCollection _geometry;
 
-        public void CreateFromLotAssets(uint patternGuid, RoofCollection roofs)
+        public void CreateFromLotArchitecture(LotArchitecture architecture)
         {
-            _roofs = roofs;
+            _architecture = architecture;
 
-            if (patternGuid == 0)
-            {
-                patternGuid = DefaultGUID;
-            }
-
-            LoadPatterns(patternGuid);
+            LoadPatterns(architecture.Roof.PatternGUID);
             BuildRoofs();
         }
 
@@ -77,7 +70,7 @@ namespace OpenTS2.Scenes.Lot
 
             if (roof == null)
             {
-                LoadPatterns(DefaultGUID);
+                LoadPatterns(RoofCollection.DefaultGUID);
                 return;
             }
 
@@ -94,7 +87,7 @@ namespace OpenTS2.Scenes.Lot
             {
                 _geometry.Clear();
 
-                _roofs.GenerateGeometry(_geometry);
+                _architecture.Roof.GenerateGeometry(_geometry);
 
                 _geometry.Commit();
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
@@ -13,7 +13,7 @@ namespace OpenTS2.Scenes.Lot
 {
     public class LotRoofComponent : AssetReferenceComponent
     {
-        private const int DefaultGUID = 0x2CDCC1F8;
+        private const uint DefaultGUID = 0x0cdcc049;
 
         private RoofCollection _roofs;
         private RoofGeometryCollection _geometry;
@@ -50,7 +50,7 @@ namespace OpenTS2.Scenes.Lot
                         { "stdMatBaseTextureAddressingV", "tile" },
                         { "stdMatBaseTextureEnabled", "true" },
                         { "stdMatBaseTextureName", textureName },
-                        { "stdMatDiffCoef", "0.8,0.8,0.8,1" },
+                        { "stdMatDiffCoef", "0.5,0.5,0.5,1" },
                         { "stdMatEmissiveCoef", "0,0,0" },
                         { "stdMatEnvCubeCoef", "0,0,0,0,0" },
                         { "stdMatLayer", "0" },

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
@@ -87,6 +87,7 @@ namespace OpenTS2.Scenes.Lot
                     new PatternDescriptor(roof.TextureUnder, GenerateMaterial(roof.TextureUnder).GetAsUnityMaterial())
                 },
                 Array.Empty<PatternVariant>(),
+                null,
                 _architecture.FloorPatterns.Depth);
         }
 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs
@@ -1,0 +1,103 @@
+using OpenTS2.Common;
+using OpenTS2.Components;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Content.DBPF.Scenegraph;
+using OpenTS2.Files.Formats.DBPF;
+using OpenTS2.Files.Formats.DBPF.Scenegraph.Block;
+using OpenTS2.Files.Formats.DBPF.Scenegraph;
+using OpenTS2.Scenes.Lot.Roof;
+using System.Collections.Generic;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public class LotRoofComponent : AssetReferenceComponent
+    {
+        private const int DefaultGUID = 0x2CDCC1F8;
+
+        private RoofCollection _roofs;
+        private RoofGeometryCollection _geometry;
+
+        public void CreateFromLotAssets(uint patternGuid, RoofCollection roofs)
+        {
+            _roofs = roofs;
+
+            if (patternGuid == 0)
+            {
+                patternGuid = DefaultGUID;
+            }
+
+            LoadPatterns(patternGuid);
+            BuildRoofs();
+        }
+
+        private ScenegraphMaterialDefinitionAsset GenerateMaterial(string textureName)
+        {
+            var persistType = new PersistTypeInfo("cSGResource", 0, 2);
+
+            var mat = new ScenegraphMaterialDefinitionAsset(
+                new MaterialDefinitionBlock(persistType,
+                    new ScenegraphResource(),
+                    textureName,
+                    "Floor",
+                    new Dictionary<string, string>()
+                    {
+                        { "deprecatedStdMatInvDiffuseCoeffMultiplier", "1.2" },
+                        { "floorMaterialScaleU", "1.000000" },
+                        { "floorMaterialScaleV", "1.000000" },
+                        { "reflectivity", "0.5" },
+                        { "stdMatBaseTextureAddressingU", "tile" },
+                        { "stdMatBaseTextureAddressingV", "tile" },
+                        { "stdMatBaseTextureEnabled", "true" },
+                        { "stdMatBaseTextureName", textureName },
+                        { "stdMatDiffCoef", "0.8,0.8,0.8,1" },
+                        { "stdMatEmissiveCoef", "0,0,0" },
+                        { "stdMatEnvCubeCoef", "0,0,0,0,0" },
+                        { "stdMatLayer", "0" },
+                        { "stdMatSpecCoef", "0,0,0" },
+                        { "stdMatUntexturedDiffAlpha", "1" }
+                    },
+                    new string[] { textureName }
+                )
+            );
+
+            mat.TGI = new ResourceKey(textureName + "_txmt", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXTR);
+
+            AddReference(mat);
+
+            return mat;
+        }
+
+        public void LoadPatterns(uint guid)
+        {
+            var contentProvider = ContentProvider.Get();
+            var catalogManager = CatalogManager.Get();
+
+            CatalogRoofAsset roof = catalogManager.GetRoofById(guid);
+
+            if (roof == null)
+            {
+                LoadPatterns(DefaultGUID);
+                return;
+            }
+
+            _geometry = new RoofGeometryCollection(
+                new PatternMesh(gameObject, roof.TextureTop, GenerateMaterial(roof.TextureTop).GetAsUnityMaterial()),
+                new PatternMesh(gameObject, roof.TextureEdges, GenerateMaterial(roof.TextureEdges).GetAsUnityMaterial()),
+                new PatternMesh(gameObject, roof.TextureTrim, GenerateMaterial(roof.TextureTrim).GetAsUnityMaterial()),
+                new PatternMesh(gameObject, roof.TextureUnder, GenerateMaterial(roof.TextureUnder).GetAsUnityMaterial()));
+        }
+
+        public void BuildRoofs()
+        {
+            if (_geometry.Valid())
+            {
+                _geometry.Clear();
+
+                _roofs.GenerateGeometry(_geometry);
+
+                _geometry.Commit();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotRoofComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a824f904dc366e4d830919bfbb98d6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
@@ -34,7 +34,7 @@ namespace OpenTS2.Scenes.Lot
         private PatternMesh _terrain;
         private PatternMesh _water;
 
-        public void CreateFromLotArchitecture(LotArchitecture architecture)
+        public LotTerrainComponent CreateFromLotArchitecture(LotArchitecture architecture)
         {
             _architecture = architecture;
 
@@ -46,6 +46,8 @@ namespace OpenTS2.Scenes.Lot
             GenerateBlendBitmap();
 
             BindMaterialAndTextures();
+
+            return this;
         }
 
         private (ScenegraphTextureAsset color, ScenegraphTextureAsset bump) LoadTexture(ContentProvider contentProvider, string name)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
@@ -125,7 +125,7 @@ namespace OpenTS2.Scenes.Lot
             if (_blendMasks == null)
             {
                 _blendMasks = new Texture2DArray(maskWidth, maskHeight, blendMaskData.Length, TextureFormat.R8, false);
-                _blendMasks.wrapMode = TextureWrapMode.Clamp;
+                _blendMasks.wrapMode = TextureWrapMode.Repeat;
             }
 
             int i = 0;
@@ -355,7 +355,7 @@ namespace OpenTS2.Scenes.Lot
                 // This is RUint, but for some reason that is not a choice, so we cast in the shader.
                 _blendBitmap = new Texture2D(bitmapWidth, bitmapHeight, TextureFormat.RFloat, false);
                 _blendBitmap.filterMode = FilterMode.Point;
-                _blendBitmap.wrapMode = TextureWrapMode.Clamp;
+                _blendBitmap.wrapMode = TextureWrapMode.Repeat;
             }
 
             _blendBitmap.SetPixelData(blendDataF, 0);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
@@ -26,10 +26,10 @@ namespace OpenTS2.Scenes.Lot
     {
 
         private LotTexturesAsset _textures;
-        private _3DArrayAsset<float> _elevationData;
-        private _2DArrayAsset<byte>[] _blendMaskData;
-        private _2DArrayAsset<float> _waterHeightData;
-        private _3DArrayAsset<Vector4<ushort>> _patternData;
+        private _3DArrayView<float> _elevationData;
+        private _2DArrayView<byte>[] _blendMaskData;
+        private _2DArrayView<float> _waterHeightData;
+        private _3DArrayView<Vector4<ushort>> _patternData;
         private int _baseLevel;
 
         private Texture2D _baseTexture;
@@ -42,10 +42,10 @@ namespace OpenTS2.Scenes.Lot
 
         public void CreateFromTerrainAssets(
             LotTexturesAsset textures,
-            _3DArrayAsset<float> elevation,
-            _2DArrayAsset<byte>[] blend,
-            _2DArrayAsset<float> waterHeightmap,
-            _3DArrayAsset<Vector4<ushort>> patterns,
+            _3DArrayView<float> elevation,
+            _2DArrayView<byte>[] blend,
+            _2DArrayView<float> waterHeightmap,
+            _3DArrayView<Vector4<ushort>> patterns,
             int baseLevel)
         {
             // Some constraints...

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
@@ -29,6 +29,7 @@ namespace OpenTS2.Scenes.Lot
         private LotTexturesAsset _textures;
         private _3DArrayAsset<float> _elevationData;
         private _2DArrayAsset<byte>[] _blendMaskData;
+        private _2DArrayAsset<float> _waterHeightData;
         private int _baseLevel;
 
         private Texture2D _baseTexture;
@@ -36,10 +37,12 @@ namespace OpenTS2.Scenes.Lot
         private RenderTexture _blendTextures;
         private Texture2DArray _blendMasks;
 
+        private Mesh _waterMesh;
         private Mesh _terrainMesh;
         private Material _material;
+        private Material _waterMaterial;
 
-        public void CreateFromTerrainAssets(LotTexturesAsset textures, _3DArrayAsset<float> elevation, _2DArrayAsset<byte>[] blend, int baseLevel)
+        public void CreateFromTerrainAssets(LotTexturesAsset textures, _3DArrayAsset<float> elevation, _2DArrayAsset<byte>[] blend, _2DArrayAsset<float> waterHeightmap, int baseLevel)
         {
             // Some constraints...
             // Heightmap size must match size in textures, and all blend sizes must be 4x (-1) on both axis.
@@ -47,7 +50,12 @@ namespace OpenTS2.Scenes.Lot
 
             if (textures.Width != elevation.Width - 1 || textures.Height != elevation.Height - 1)
             {
-                throw new InvalidOperationException("Size mismatch between heightmap and LTTX");
+                throw new InvalidOperationException("Size mismatch between elevation and LTTX");
+            }
+
+            if (waterHeightmap.Width != elevation.Width || waterHeightmap.Height != elevation.Height)
+            {
+                throw new InvalidOperationException("Size mismatch between elevation and water heightmap");
             }
 
             if (textures.BlendTextures.Length != blend.Length)
@@ -65,6 +73,7 @@ namespace OpenTS2.Scenes.Lot
 
             _textures = textures;
             _elevationData = elevation;
+            _waterHeightData = waterHeightmap;
             _blendMaskData = blend;
             _baseLevel = baseLevel;
 
@@ -169,6 +178,10 @@ namespace OpenTS2.Scenes.Lot
                 _terrainMesh = new Mesh();
 
                 _material = new Material(Shader.Find("OpenTS2/Terrain"));
+
+                _waterMesh = new Mesh();
+
+                _waterMaterial = new Material(Shader.Find("OpenTS2/Water"));
             }
         }
 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs
@@ -1,0 +1,341 @@
+using OpenTS2.Common;
+using OpenTS2.Components;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Content.DBPF.Scenegraph;
+using OpenTS2.Files.Formats.DBPF;
+using System;
+using System.Runtime.InteropServices;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace OpenTS2.Scenes.Lot
+{
+    [StructLayout(LayoutKind.Explicit)]
+    struct IntToFloat
+    {
+        [FieldOffset(0)] private float f;
+        [FieldOffset(0)] private uint i;
+        public static float Convert(uint value)
+        {
+            return new IntToFloat { i = value }.f;
+        }
+    }
+
+    [RequireComponent(typeof(MeshFilter))]
+    [RequireComponent(typeof(MeshRenderer))]
+    public class LotTerrainComponent : AssetReferenceComponent
+    {
+        private LotTexturesAsset _textures;
+        private _3DArrayAsset<float> _elevationData;
+        private _2DArrayAsset<byte>[] _blendMaskData;
+        private int _baseLevel;
+
+        private Texture2D _baseTexture;
+        private Texture2D _blendBitmap;
+        private RenderTexture _blendTextures;
+        private Texture2DArray _blendMasks;
+
+        private Mesh _terrainMesh;
+        private Material _material;
+
+        public void CreateFromTerrainAssets(LotTexturesAsset textures, _3DArrayAsset<float> elevation, _2DArrayAsset<byte>[] blend, int baseLevel)
+        {
+            // Some constraints...
+            // Heightmap size must match size in textures, and all blend sizes must be 4x (-1) on both axis.
+            // Blend textures must have the same count as the # of blend masks.
+
+            if (textures.Width != elevation.Width - 1 || textures.Height != elevation.Height - 1)
+            {
+                throw new InvalidOperationException("Size mismatch between heightmap and LTTX");
+            }
+
+            if (textures.BlendTextures.Length != blend.Length)
+            {
+                throw new InvalidOperationException("Blend texture count mismatch between LOTG and LTTX");
+            }
+
+            foreach (var mask in blend)
+            {
+                if (mask.Width != elevation.Width * 4 - 3 || mask.Height != elevation.Height * 4 - 3)
+                {
+                    throw new InvalidOperationException("Size mismatch between mask and heightmap");
+                }
+            }
+
+            _textures = textures;
+            _elevationData = elevation;
+            _blendMaskData = blend;
+            _baseLevel = baseLevel;
+
+            LoadLotTextures();
+            GenerateTerrainVertices();
+            GenerateTerrainIndices();
+            LoadAllBlendMasks();
+            GenerateBlendBitmap();
+
+            PrepareMesh();
+            BindMaterialAndTextures();
+        }
+
+        private (ScenegraphTextureAsset color, ScenegraphTextureAsset bump) LoadTexture(ContentProvider contentProvider, string name)
+        {
+            var result = (
+                contentProvider.GetAsset<ScenegraphTextureAsset>(new ResourceKey($"{name}_txtr", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXTR)),
+                contentProvider.GetAsset<ScenegraphTextureAsset>(new ResourceKey($"{name}-bump_txtr", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXTR))
+            );
+
+            AddReference(result.Item1, result.Item2);
+
+            return result;
+        }
+
+        private void LoadLotTextures()
+        {
+            var contentProvider = ContentProvider.Get();
+
+            var baseTexture = LoadTexture(contentProvider, _textures.BaseTexture);
+
+            _baseTexture = baseTexture.color.GetSelectedImageAsUnityTexture(contentProvider);
+
+            var blendTextures = new (Texture2D color, Texture2D bump)[_textures.BlendTextures.Length];
+
+            int maxWidth = 32;
+            int maxHeight = 32;
+
+            int i = 0;
+            foreach (string name in _textures.BlendTextures)
+            {
+                var textures = LoadTexture(contentProvider, name);
+                blendTextures[i] = (textures.color?.GetSelectedImageAsUnityTexture(contentProvider) ?? Texture2D.whiteTexture, textures.bump?.GetSelectedImageAsUnityTexture(contentProvider) ?? Texture2D.whiteTexture);
+
+                maxWidth = Math.Max(Math.Max(maxWidth, blendTextures[i].color?.width ?? 0), blendTextures[i].bump?.width ?? 0);
+                maxHeight = Math.Max(Math.Max(maxHeight, blendTextures[i].color?.height ?? 0), blendTextures[i].bump?.height ?? 0);
+
+                i++;
+            }
+
+            int mips = (int)Math.Min(Math.Log(maxWidth, 2.0), Math.Log(maxHeight, 2.0));
+
+            if (_blendTextures == null)
+            {
+                // We lose compression since we might need to generate higher sized mips, as all mips need to be equal in texture arrays.
+                _blendTextures = new RenderTexture(new RenderTextureDescriptor(maxWidth, maxHeight, RenderTextureFormat.BGRA32, 0, mips));
+                _blendTextures.useMipMap = true;
+                _blendTextures.dimension = TextureDimension.Tex2DArray;
+                _blendTextures.volumeDepth = _blendMaskData.Length;
+                _blendTextures.wrapMode = TextureWrapMode.Repeat;
+            }
+
+            // TODO: bump
+
+            i = 0;
+            foreach (var tex in blendTextures)
+            {
+                float scaleW = maxWidth / (float)tex.color.width;
+                float scaleH = maxHeight / (float)tex.color.height;
+
+                Graphics.Blit(tex.color, _blendTextures, new Vector2(scaleW, scaleH), Vector2.zero, 0, i++);
+            }
+        }
+
+        private void LoadAllBlendMasks()
+        {
+            int maskWidth = (_elevationData.Width * 4 - 3);
+            int maskHeight = (_elevationData.Height * 4 - 3);
+
+            if (_blendMasks == null)
+            {
+                _blendMasks = new Texture2DArray(maskWidth, maskHeight, _blendMaskData.Length, TextureFormat.R8, false);
+                _blendMasks.wrapMode = TextureWrapMode.Clamp;
+            }
+
+            int i = 0;
+            foreach (var mask in _blendMaskData)
+            {
+                _blendMasks.SetPixelData(mask.Data, 0, i++);
+            }
+
+            _blendMasks.Apply();
+        }
+
+        private const float TerrainGridSize = 1f;
+        private const float TerrainOffset = 0f;
+
+        private void EnsureMesh()
+        {
+            if (_terrainMesh == null)
+            {
+                _terrainMesh = new Mesh();
+
+                _material = new Material(Shader.Find("OpenTS2/Terrain"));
+            }
+        }
+
+        private void GenerateTerrainVertices()
+        {
+            int width = _elevationData.Width;
+            int height = _elevationData.Height;
+
+            float[] data = _elevationData.Data[-_baseLevel];
+
+            int size = data.Length + (width - 1) * (height - 1);
+
+            var vertices = new Vector3[size];
+            var uvs = new Vector2[size];
+
+            int i = 0;
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < height; y++, i++)
+                {
+                    vertices[i] = new Vector3(x * TerrainGridSize, data[i] + TerrainOffset, y * TerrainGridSize);
+                    uvs[i] = new Vector2(x, y);
+                }
+            }
+
+            // Now for midpoints, which are an average of the 4 corners.
+
+            int mWidth = width - 1;
+            int mHeight = height - 1;
+
+            float fx = 0.5f;
+            for (int x = 0; x < mWidth; x++, fx++)
+            {
+                float fy = 0.5f;
+                int vertPos = x * height;
+                for (int y = 0; y < mHeight; y++, fy++, i++, vertPos++)
+                {
+                    float average = (data[vertPos] + data[vertPos + height] + data[vertPos + 1] + data[vertPos + height + 1]) / 4f;
+
+                    vertices[i] = new Vector3(fx * TerrainGridSize, average + TerrainOffset, fy * TerrainGridSize);
+                    uvs[i] = new Vector2(fx, fy);
+                }
+            }
+
+            EnsureMesh();
+
+            _terrainMesh.SetVertices(vertices);
+            _terrainMesh.SetUVs(0, uvs);
+        }
+
+        private void GenerateTerrainIndices()
+        {
+            // When flooring is implemented, this should avoid generating terrain triangles where there is flooring.
+            // Should also respect diagonals.
+
+            // For now, just fill every tile.
+
+            int width = _elevationData.Width - 1;
+            int height = _elevationData.Height - 1;
+
+            var indices = new int[width * height * 12];
+
+            int midOffset = _elevationData.Width * _elevationData.Height;
+
+            int i = 0;
+            int vi = 0;
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < height; y++, vi++)
+                {
+                    // Triangles wrap around a midpoint;
+                    int mid = vi + midOffset - x;
+
+                    indices[i] = vi;
+                    indices[i + 1] = vi + 1;
+                    indices[i + 2] = mid;
+
+                    indices[i + 3] = vi + 1;
+                    indices[i + 4] = vi + height + 2;
+                    indices[i + 5] = mid;
+
+                    indices[i + 6] = vi + height + 2;
+                    indices[i + 7] = vi + height + 1;
+                    indices[i + 8] = mid;
+
+                    indices[i + 9] = vi + height + 1;
+                    indices[i + 10] = vi;
+                    indices[i + 11] = mid;
+
+                    i += 12;
+                }
+
+                vi++;
+            }
+
+            EnsureMesh();
+            _terrainMesh.SetIndices(indices, MeshTopology.Triangles, 0);
+        }
+
+        private void PrepareMesh()
+        {
+            _terrainMesh.RecalculateNormals();
+            _terrainMesh.RecalculateTangents();
+
+            GetComponent<MeshFilter>().sharedMesh = _terrainMesh;
+        }
+
+        private void BindMaterialAndTextures()
+        {
+            var meshRenderer = GetComponent<MeshRenderer>();
+
+            meshRenderer.sharedMaterial = _material;
+
+            _material.SetTexture("_BaseTexture", _baseTexture);
+            _material.SetTexture("_BlendBitmap", _blendBitmap);
+            _material.SetTexture("_BlendTextures", _blendTextures);
+            _material.SetTexture("_BlendMasks", _blendMasks);
+
+            _material.SetVector("_InvLotSize", new Vector4(1f / (_elevationData.Width - 1), 1f / (_elevationData.Height - 1)));
+        }
+
+        private void GenerateBlendBitmap()
+        {
+            // The blend bitmap tells the shader what blend textures are present at each texel.
+            // This helps reduce the number of textures that need to be sampled in fragment.
+            // This could be done with a render to texture, as long as it happens whenever the blend masks change.
+
+            int bitmapWidth = (_elevationData.Width * 4 - 3);
+            int bitmapHeight = (_elevationData.Height * 4 - 3);
+
+            var size = bitmapWidth * bitmapHeight;
+
+            var blendData = new uint[size];
+
+            int bitN = 0;
+            foreach (var blend in _blendMaskData)
+            {
+                uint bit = 1u << bitN;
+
+                for (int i = 0; i < size; i++)
+                {
+                    if (blend.Data[i] > 0)
+                    {
+                        blendData[i] |= bit;
+                    }
+                }
+
+                bitN++;
+            }
+
+            var blendDataF = new float[size];
+
+            for (int i = 0; i < size; i++)
+            {
+                blendDataF[i] = IntToFloat.Convert(blendData[i]);
+            }
+
+            if (_blendBitmap == null)
+            {
+                // This is RUint, but for some reason that is not a choice, so we cast in the shader.
+                _blendBitmap = new Texture2D(bitmapWidth, bitmapHeight, TextureFormat.RFloat, false);
+                _blendBitmap.filterMode = FilterMode.Point;
+                _blendBitmap.wrapMode = TextureWrapMode.Clamp;
+            }
+
+            _blendBitmap.SetPixelData(blendDataF, 0);
+            _blendBitmap.Apply();
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotTerrainComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fcc48bc2b5a8a5249a84ef6785509308
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -293,7 +293,7 @@ namespace OpenTS2.Scenes.Lot
             var contentProvider = ContentProvider.Get();
             var catalogManager = CatalogManager.Get();
 
-            ushort highestId = _patternMap.Map.Keys.Max();
+            ushort highestId = _patternMap.Map.Count == 0 ? (ushort)0 : _patternMap.Map.Keys.Max();
             _patterns = new PatternMesh[highestId + 1];
 
             foreach (StringMapEntry entry in _patternMap.Map.Values)
@@ -597,9 +597,9 @@ namespace OpenTS2.Scenes.Lot
 
                 if (roofWall)
                 {
-                    heightTo = Mathf.Clamp(_roofs.GetHeightAt(to.XPos, to.YPos) - RoofOffset, floorTo, heightTo);
-                    heightMid = Mathf.Clamp(_roofs.GetHeightAt(midX, midY) - RoofOffset, floorMid, heightMid);
-                    heightFrom = Mathf.Clamp(_roofs.GetHeightAt(from.XPos, from.YPos) - RoofOffset, floorFrom, heightFrom);
+                    heightTo = Mathf.Max(_roofs.GetHeightAt(to.XPos, to.YPos, heightTo) - RoofOffset, floorTo);
+                    heightMid = Mathf.Max(_roofs.GetHeightAt(midX, midY, heightTo) - RoofOffset, floorMid);
+                    heightFrom = Mathf.Max(_roofs.GetHeightAt(from.XPos, from.YPos, heightTo) - RoofOffset, floorFrom);
                 }
 
                 wallVertices[3] = new Vector3(to.XPos, heightTo, to.YPos);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -37,6 +37,14 @@ namespace OpenTS2.Scenes.Lot
         private const float Thickness = 0.075f;
         private const float RoofOffset = Thickness * 2.5f;
 
+        private static Dictionary<string, string> Builtins = new Dictionary<string, string>()
+        {
+            { "blank", FallbackMaterial },
+            { "deckskirtminimal", null },
+            { "foundationbrick", "wall_brick_base" },
+            { "wall_poolroundedlipblue", "wall_poolroundedlipblue_base" }
+        };
+
         private class FenceCollection
         {
             private CatalogFenceAsset _asset;
@@ -306,13 +314,15 @@ namespace OpenTS2.Scenes.Lot
 
                     materialName = catalogEntry?.Material ?? FallbackMaterial;
                 }
-                else if (entry.Value == "blank")
-                {
-                    materialName = FallbackMaterial;
-                }
-                else
+                else if (!Builtins.TryGetValue(entry.Value, out materialName))
                 {
                     materialName = entry.Value.StartsWith("wall_") ? (entry.Value + "_base") : ("wall_" + entry.Value + "_base");
+                }
+
+                if (materialName == null)
+                {
+                    // Explicitly remove this pattern.
+                    continue;
                 }
 
                 // Try fetch the texture using the material name.
@@ -520,7 +530,7 @@ namespace OpenTS2.Scenes.Lot
 
             int currentFloor = 0;
             float[] currentFloorElevation = _elevationData.Data[currentFloor];
-            float[] nextFloorElevation = _elevationData.Data[currentFloor + 1];
+            float[] nextFloorElevation = currentFloor + 1 < floors ? _elevationData.Data[currentFloor + 1] : null;
 
             Vector3[] wallVertices = new Vector3[6];
             Vector3[] wallVertices2 = new Vector3[6];
@@ -590,8 +600,8 @@ namespace OpenTS2.Scenes.Lot
                     }
                 }
 
-                LotFloorPatternComponent lPattern = (layerElem.Pattern1 == 65535 ? null : _patterns[layerElem.Pattern1]?.Component);// ?? _thickness?.Component;
-                LotFloorPatternComponent rPattern = (layerElem.Pattern2 == 65535 ? null : _patterns[layerElem.Pattern2]?.Component);// ?? _thickness?.Component;
+                LotArchitectureMeshComponent lPattern = (layerElem.Pattern1 == 65535 ? null : _patterns[layerElem.Pattern1]?.Component);// ?? _thickness?.Component;
+                LotArchitectureMeshComponent rPattern = (layerElem.Pattern2 == 65535 ? null : _patterns[layerElem.Pattern2]?.Component);// ?? _thickness?.Component;
 
                 float midX = (from.XPos + to.XPos) / 2;
                 float midY = (from.YPos + to.YPos) / 2;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -238,7 +238,7 @@ namespace OpenTS2.Scenes.Lot
         private WallLayerAsset _wallLayer;
         private WallGraphAsset _wallGraph;
         private FencePostLayerAsset _fencePosts;
-        private _3DArrayAsset<float> _elevationData;
+        private _3DArrayView<float> _elevationData;
         private RoofCollection _roofs;
 
         private PatternMesh _thickness;
@@ -252,7 +252,7 @@ namespace OpenTS2.Scenes.Lot
             WallLayerAsset wallLayer,
             WallGraphAsset wallGraph,
             FencePostLayerAsset fencePosts,
-            _3DArrayAsset<float> elevationData,
+            _3DArrayView<float> elevationData,
             RoofCollection roofs)
         {
             _patternMap = patternMap;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -1,0 +1,703 @@
+using Codice.Client.BaseCommands.BranchExplorer;
+using OpenTS2.Common;
+using OpenTS2.Components;
+using OpenTS2.Content;
+using OpenTS2.Content.DBPF;
+using OpenTS2.Content.DBPF.Scenegraph;
+using OpenTS2.Diagnostic;
+using OpenTS2.Files.Formats.DBPF;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public static class WallType
+    {
+        public const int Normal = 1;
+        public const int ThinFence = 2; // unused?
+        public const int Roof = 3;
+        public const int DeckInvis = 4;
+        public const int Deck = 16;
+        public const int Foundation = 23;
+        public const int Deck2 = 24;
+        public const int Deck3 = 26;
+        public const int Pool = 29;
+        public const int OFBWall = 300;
+        public const int OFBScreen = 301;
+    }
+
+    public class LotWallComponent : AssetReferenceComponent
+    {
+        private const string ThicknessTexture = "wall_top";
+        private const string FallbackMaterial = "wall_wallboard";
+        private const float HalfWallHeight = 1f;
+        private const float WallHeight = 3f;
+        private const float Thickness = 0.075f;
+
+        private class PatternMesh
+        {
+            public GameObject Object;
+            public LotFloorPatternComponent Component;
+
+            public PatternMesh(GameObject parent, string name, Material material)
+            {
+                Object = new GameObject(name, typeof(LotFloorPatternComponent));
+                Component = Object.GetComponent<LotFloorPatternComponent>();
+
+                Object.transform.SetParent(parent.transform);
+                Component.Initialize(material);
+            }
+        }
+
+        private class FenceCollection
+        {
+            private CatalogFenceAsset _asset;
+            private ContentProvider _contentProvider;
+            private GameObject _parent;
+            private bool _hasDiag;
+
+            private ScenegraphResourceAsset _railCres;
+            private ScenegraphResourceAsset _diagRailCres;
+            private ScenegraphResourceAsset _postCres;
+
+            private List<GameObject> _rails;
+            private List<GameObject> _diagRails;
+            private List<GameObject> _posts;
+
+            public FenceCollection(ContentProvider contentProvider, GameObject parent, uint guid)
+            {
+                var catalog = CatalogManager.Get();
+
+                _asset = catalog.GetFenceById(guid);
+
+                if (_asset == null)
+                {
+                    return;
+                }
+
+                _hasDiag = _asset.DiagRail != null;
+                _parent = parent;
+
+                _railCres = contentProvider.GetAsset<ScenegraphResourceAsset>(
+                    new ResourceKey(_asset.Rail + "_cres", GroupIDs.Scenegraph,
+                        TypeIDs.SCENEGRAPH_CRES));
+
+                _diagRailCres = _hasDiag ? contentProvider.GetAsset<ScenegraphResourceAsset>(
+                    new ResourceKey(_asset.DiagRail + "_cres", GroupIDs.Scenegraph,
+                        TypeIDs.SCENEGRAPH_CRES)) : null;
+
+                _postCres = contentProvider.GetAsset<ScenegraphResourceAsset>(
+                    new ResourceKey(_asset.Post + "_cres", GroupIDs.Scenegraph,
+                        TypeIDs.SCENEGRAPH_CRES));
+
+                _rails = new List<GameObject>();
+                _diagRails = new List<GameObject>();
+                _posts = new List<GameObject>();
+
+                parent.GetComponent<LotWallComponent>().AddReference(_railCres, _diagRailCres, _postCres);
+            }
+
+            public void AddRail(float fromX, float fromY, float toX, float toY, float fromElevation, float toElevation)
+            {
+                float direction = Mathf.Rad2Deg * Mathf.Atan2(toY - fromY, toX - fromX);
+                Vector3 shearVec = new Vector3(toX - fromX, toY - fromY, toElevation - fromElevation);
+                float magnitude = new Vector2(toX - fromX, toY - fromY).magnitude;
+                float shearMagnitude = shearVec.magnitude;
+
+                GameObject model;
+
+                if (magnitude > 1.1 && _diagRailCres != null)
+                {
+                    model = _diagRailCres.CreateRootGameObject();
+
+                    model.transform.parent = _parent.transform;
+
+                    magnitude /= Mathf.Sqrt(2);
+
+                    _diagRails.Add(model);
+                }
+                else
+                {
+                    if (_railCres != null)
+                    {
+                        model = _railCres.CreateRootGameObject();
+
+                        model.transform.parent = _parent.transform;
+
+                        _rails.Add(model);
+                    }
+                    else
+                    {
+                        return;
+                    }
+                }
+
+                Transform modelSpace = model.transform.GetChild(0);
+                modelSpace.localScale = new Vector3(magnitude, 1, 1);
+
+                if (shearVec.z != 0)
+                {
+                    // Shear transform
+                    // Because Unity doesn't support submitting your own transform matrix for some reason,
+                    // We need to combine a bunch of transformations to perform a shear.
+                    // In this case, we want the Z dimension to be sheared with x and y left intact.
+
+                    float realAngle = Mathf.Atan2(shearVec.z, magnitude);
+                    float shearAngle = realAngle > 0 ? Mathf.PI / 2 - realAngle : Mathf.PI / -2 - realAngle;
+
+                    var top = new GameObject("skew_top").transform;
+                    top.SetParent(model.transform);
+                    var mid = new GameObject("skew_mid").transform;
+                    mid.SetParent(top);
+                    var bot = new GameObject("skew_bot").transform;
+                    bot.SetParent(mid);
+                    modelSpace.SetParent(bot);
+                    modelSpace.localRotation = Quaternion.identity;
+
+                    top.localRotation = Quaternion.Euler(0, -realAngle * Mathf.Rad2Deg, 0);
+                    mid.localRotation = Quaternion.Euler(0, 45, 0);
+                    bot.localRotation = Quaternion.Euler(0, (-shearAngle / 2) * Mathf.Rad2Deg, 0);
+
+                    float initialScale = shearMagnitude;
+                    float finalScale = Mathf.Sqrt(2);
+
+                    top.localScale = new Vector3(finalScale / Mathf.Sin(shearAngle), 1, finalScale);
+                    mid.localScale = new Vector3(Mathf.Sin(shearAngle / 2), 1, Mathf.Cos(shearAngle / 2));
+                    bot.localScale = new Vector3(initialScale, 1, 1 / initialScale);
+
+                    modelSpace = top;
+                }
+
+                modelSpace.localPosition = new Vector3(fromX, fromY, fromElevation);
+                modelSpace.localRotation = Quaternion.Euler(0, 0, direction) * modelSpace.localRotation;
+            }
+
+            public void AddPost(float x, float y, float elevation)
+            {
+                if (_postCres != null)
+                {
+                    var model = _postCres.CreateRootGameObject();
+
+                    model.transform.parent = _parent.transform;
+
+                    model.transform.GetChild(0).localPosition = new Vector3(x, y, elevation);
+
+                    _posts.Add(model);
+                }
+            }
+
+            public void Clear()
+            {
+                foreach (GameObject rail in _rails)
+                {
+                    Destroy(rail);
+                }
+
+                foreach (GameObject rail in _diagRails)
+                {
+                    Destroy(rail);
+                }
+
+                foreach (GameObject post in _posts)
+                {
+                    Destroy(post);
+                }
+
+                _rails.Clear();
+                _posts.Clear();
+            }
+        }
+
+        private struct WallIntersectionMember
+        {
+            public int WallID;
+            public float LeftExtent;
+            public float RightExtent;
+
+            public WallIntersectionMember(int wallId)
+            {
+                WallID = wallId;
+                LeftExtent = 0;
+                RightExtent = 0;
+            }
+        }
+
+        private class WallIntersection
+        {
+            public WallGraphPositionEntry Position;
+            public List<WallIntersectionMember> IncomingLines;
+            public bool Simple; // Wall intersection is flat or capped.
+
+            public WallIntersection(WallGraphPositionEntry position)
+            {
+                Position = position;
+                IncomingLines = new List<WallIntersectionMember>();
+                Simple = true;
+            }
+        }
+
+        private StringMapAsset _patternMap;
+        private WallLayerAsset _wallLayer;
+        private WallGraphAsset _wallGraph;
+        private FencePostLayerAsset _fencePosts;
+        private _3DArrayAsset<float> _elevationData;
+
+        private PatternMesh _thickness;
+        private PatternMesh[] _patterns;
+
+        private Dictionary<int, WallIntersection> _intersections;
+        private Dictionary<uint, FenceCollection> _fenceByGuid;
+
+        public void CreateFromLotAssets(StringMapAsset patternMap, WallLayerAsset wallLayer, WallGraphAsset wallGraph, FencePostLayerAsset fencePosts, _3DArrayAsset<float> elevationData)
+        {
+            _patternMap = patternMap;
+            _wallLayer = wallLayer;
+            _wallGraph = wallGraph;
+            _fencePosts = fencePosts;
+            _elevationData = elevationData;
+            _fenceByGuid = new Dictionary<uint, FenceCollection>();
+
+            if (wallGraph.Floors != elevationData.Depth)
+            {
+                throw new InvalidOperationException("Size mismatch between elevation and wall graph");
+            }
+
+            LoadPatterns();
+            BuildWallIntersections();
+            BuildWallMeshes();
+            AddFencePosts();
+        }
+
+        private ScenegraphMaterialDefinitionAsset LoadMaterial(ContentProvider contentProvider, string name)
+        {
+            var material = contentProvider.GetAsset<ScenegraphMaterialDefinitionAsset>(new ResourceKey($"{name}_txmt", GroupIDs.Scenegraph, TypeIDs.SCENEGRAPH_TXMT));
+
+            AddReference(material);
+
+            return material;
+        }
+
+        private FenceCollection GetFence(uint guid)
+        {
+            if (!_fenceByGuid.TryGetValue(guid, out FenceCollection result))
+            {
+                result = new FenceCollection(ContentProvider.Get(), gameObject, guid);
+
+                _fenceByGuid[guid] = result;
+            }
+
+            return result;
+        }
+
+        private void LoadPatterns()
+        {
+            // Load the patterns. Some references are by asset name (do not exist in catalog), others are by catalog GUID.
+
+            var contentProvider = ContentProvider.Get();
+            var catalogManager = CatalogManager.Get();
+
+            ushort highestId = _patternMap.Map.Keys.Max();
+            _patterns = new PatternMesh[highestId + 1];
+
+            foreach (StringMapEntry entry in _patternMap.Map.Values)
+            {
+                string materialName;
+                if (uint.TryParse(entry.Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out uint guid))
+                {
+                    var catalogEntry = catalogManager.GetEntryById(guid);
+
+                    materialName = catalogEntry?.Material ?? FallbackMaterial;
+                }
+                else if (entry.Value == "blank")
+                {
+                    materialName = FallbackMaterial;
+                }
+                else
+                {
+                    materialName = entry.Value.StartsWith("wall_") ? (entry.Value + "_base") : ("wall_" + entry.Value + "_base");
+                }
+
+                // Try fetch the texture using the material name.
+
+                var material = LoadMaterial(contentProvider, materialName);
+
+                if (material == null)
+                {
+
+                }
+
+                _patterns[entry.Id] = material == null ? null : new PatternMesh(gameObject, materialName, material?.GetAsUnityMaterial());
+            }
+
+            _thickness = new PatternMesh(gameObject, ThicknessTexture, LoadMaterial(contentProvider, ThicknessTexture).GetAsUnityMaterial());
+        }
+
+        private bool IsWallThick(int type)
+        {
+            switch (type)
+            {
+                case WallType.Normal:
+                case WallType.Roof:
+                case WallType.Foundation:
+                case WallType.Pool:
+                case WallType.OFBWall:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private bool IsFence(int type)
+        {
+            return (uint)type > 255;
+        }
+
+        private static int CalculateElevationIndex(int height, int x, int y)
+        {
+            return x * height + y;
+        }
+
+        private static float GetElevationInt(float[] elevation, int width, int height, float x, float y)
+        {
+            return elevation[CalculateElevationIndex(height, (int)x, (int)y)];
+        }
+
+        private static float GetElevationIntUpper(float[] elevation, int width, int height, float x, float y, float previous)
+        {
+            return elevation == null ? previous + WallHeight : elevation[CalculateElevationIndex(height, (int)x, (int)y)];
+        }
+
+        private static float GetElevationInterp(float[] elevation, int width, int height, float x, float y)
+        {
+            // TODO
+            return 0f;
+        }
+
+        private WallIntersection GetOrAddIntersection(int id)
+        {
+            if (_intersections.TryGetValue(id, out WallIntersection intersection))
+            {
+                return intersection;
+            }
+
+            intersection = new WallIntersection(_wallGraph.Positions[id]);
+            _intersections.Add(id, intersection);
+
+            return intersection;
+        }
+
+        private void AddToIntersection(WallIntersection intersection, ref WallGraphLineEntry line, int lineIndex, bool isTo)
+        {
+            WallIntersectionMember newMember = new WallIntersectionMember(lineIndex);
+
+            if (intersection.IncomingLines.Count > 0)
+            {
+                // Evaluate extents for new line, update others based on preference.
+
+                ref WallGraphPositionEntry pos = ref intersection.Position;
+                WallGraphPositionEntry inFrom = isTo ? _wallGraph.Positions[line.FromId] : _wallGraph.Positions[line.ToId]; //y
+
+                Vector2 vecIntoIntersection = new Vector2(pos.XPos - inFrom.XPos, pos.YPos - inFrom.YPos);
+                vecIntoIntersection.Normalize();
+
+                int count = intersection.IncomingLines.Count;
+
+                newMember.LeftExtent = float.PositiveInfinity;
+                newMember.RightExtent = float.PositiveInfinity;
+
+                for (int i = 0; i < count; i++)
+                {
+                    WallIntersectionMember otherMember = intersection.IncomingLines[i];
+
+                    ref WallGraphLineEntry otherLine = ref _wallGraph.Lines[otherMember.WallID];
+                    bool otherTo = otherLine.FromId == intersection.Position.Id;
+                    WallGraphPositionEntry outTo = otherTo ?
+                        _wallGraph.Positions[otherLine.ToId] :
+                        _wallGraph.Positions[otherLine.FromId];
+
+                    Vector2 vecOutIntersection = new Vector2(outTo.XPos - pos.XPos, outTo.YPos - pos.YPos);
+
+                    vecOutIntersection.Normalize();
+
+                    float dot = Vector2.Dot(vecIntoIntersection, vecOutIntersection);
+
+                    if (Mathf.Approximately(dot, 1f) && count == 1)
+                    {
+                        // If the two lines are facing the same direction, the extents are still 0 and this is still the simple case.
+
+                        newMember.LeftExtent = 0;
+                        newMember.RightExtent = 0;
+
+                        break;
+                    }
+
+                    float vecAngle = Mathf.Acos(dot) * Mathf.Sign(vecIntoIntersection.x * vecOutIntersection.y - vecIntoIntersection.y * vecOutIntersection.x);
+                    float angle = (vecAngle) / 2;
+
+                    float extent = Thickness * Mathf.Tan(angle);
+
+                    // When incoming, the left side extends forwards by extent, right side extends forwards by -extent.
+                    // When outgoing, it's the opposite, as an incoming line's left side is the right side of the outgoing version.
+                    // Prefer the smallest extent between both lines in the intersection.
+
+                    float newSign = isTo ? 1 : -1;
+                    newMember.LeftExtent = Math.Min(extent * newSign, newMember.LeftExtent);
+                    newMember.RightExtent = Math.Min(-extent * newSign, newMember.RightExtent);
+
+                    if (count == 1)
+                    {
+                        // Prepare these for getting new extents. Only saved back in non-simple-cases.
+                        otherMember.LeftExtent = float.PositiveInfinity;
+                        otherMember.RightExtent = float.PositiveInfinity;
+                    }
+
+                    float otherSign = otherTo ? 1 : -1;
+
+                    otherMember.LeftExtent = Math.Min(extent * otherSign, otherMember.LeftExtent);
+                    otherMember.RightExtent = Math.Min(-extent * otherSign, otherMember.RightExtent);
+
+                    // Save back new extents.
+                    intersection.IncomingLines[i] = otherMember;
+                }
+            }
+
+            intersection.IncomingLines.Add(newMember);
+        }
+
+        private void BuildWallIntersections()
+        {
+            WallGraphLineEntry[] lines = _wallGraph.Lines;
+            _intersections = new Dictionary<int, WallIntersection>();
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                ref WallGraphLineEntry line = ref lines[i];
+                WallIntersection from = GetOrAddIntersection(line.FromId);
+                WallIntersection to = GetOrAddIntersection(line.ToId);
+
+                if (_wallLayer.Walls.TryGetValue(line.LayerId, out var layer) && IsWallThick(layer.WallType))
+                {
+                    // Add this line to both intersections
+                    AddToIntersection(from, ref line, i, false);
+                    AddToIntersection(to, ref line, i, true);
+                }
+            }
+        }
+
+        private void BuildWallMeshes()
+        {
+            // TODO: split pattern meshes by level?
+            int width = _elevationData.Width;
+            int height = _elevationData.Height;
+            int floors = _elevationData.Depth;
+            int baseFloor = _wallGraph.BaseFloor;
+
+            WallGraphLineEntry[] lines = _wallGraph.Lines;
+            Dictionary<int, WallGraphPositionEntry> positions = _wallGraph.Positions;
+            Dictionary<int, WallLayerEntry> layer = _wallLayer.Walls;
+
+            // Draw each line on the wall graph.
+
+            int currentFloor = 0;
+            float[] currentFloorElevation = _elevationData.Data[currentFloor];
+            float[] nextFloorElevation = _elevationData.Data[currentFloor + 1];
+
+            Vector3[] wallVertices = new Vector3[4];
+            Vector3[] wallVertices2 = new Vector3[4];
+            Vector2[] wallUVs = new Vector2[4];
+
+            Vector3[] thicknessVerts = new Vector3[6];
+            Vector2[] thicknessUVs = new Vector2[6];
+
+            var thicknessComp = _thickness.Component;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                ref WallGraphLineEntry line = ref lines[i];
+
+                WallIntersection fromI = _intersections[line.FromId];
+                WallIntersection toI = _intersections[line.ToId];
+
+                ref WallGraphPositionEntry from = ref fromI.Position;
+                ref WallGraphPositionEntry to = ref toI.Position;
+
+                int floor = from.Level - baseFloor;
+
+                if (floor != currentFloor)
+                {
+                    currentFloor = floor;
+
+                    currentFloorElevation = _elevationData.Data[floor];
+                    nextFloorElevation = floor + 1 < floors ? _elevationData.Data[floor + 1] : null;
+                }
+
+                if (!layer.TryGetValue(line.LayerId, out WallLayerEntry layerElem))
+                {
+                    layerElem = new WallLayerEntry()
+                    {
+                        Id = line.LayerId,
+                        Pattern1 = 65535,
+                        Pattern2 = 65535,
+                        WallType = 2
+                    };
+
+                    // This shouldn't happen...
+                }
+                
+                if (IsFence(layerElem.WallType))
+                {
+                    var fence = GetFence((uint)layerElem.WallType);
+
+                    fence.AddRail(
+                        from.XPos,
+                        from.YPos,
+                        to.XPos,
+                        to.YPos,
+                        GetElevationInt(currentFloorElevation, width, height, from.XPos, from.YPos),
+                        GetElevationInt(currentFloorElevation, width, height, to.XPos, to.YPos));
+                }
+
+                LotFloorPatternComponent lPattern = (layerElem.Pattern1 == 65535 ? null : _patterns[layerElem.Pattern1]?.Component);// ?? _thickness?.Component;
+                LotFloorPatternComponent rPattern = (layerElem.Pattern2 == 65535 ? null : _patterns[layerElem.Pattern2]?.Component);// ?? _thickness?.Component;
+
+                wallVertices[0] = new Vector3(from.XPos, GetElevationInt(currentFloorElevation, width, height, from.XPos, from.YPos), from.YPos);
+                wallVertices[1] = new Vector3(to.XPos, GetElevationInt(currentFloorElevation, width, height, to.XPos, to.YPos), to.YPos);
+
+                wallVertices[2] = new Vector3(to.XPos, GetElevationIntUpper(nextFloorElevation, width, height, to.XPos, to.YPos, wallVertices[1].y), to.YPos);
+                wallVertices[3] = new Vector3(from.XPos, GetElevationIntUpper(nextFloorElevation, width, height, from.XPos, from.YPos, wallVertices[0].y), from.YPos);
+
+                wallUVs[0] = new Vector2(0, (wallVertices[3].y - wallVertices[0].y) / WallHeight);
+                wallUVs[1] = new Vector2(1, (wallVertices[2].y - wallVertices[1].y) / WallHeight);
+                wallUVs[2] = new Vector2(1, 0);
+                wallUVs[3] = new Vector2(0, 0);
+
+                bool isThick = IsWallThick(layerElem.WallType);
+
+                if (isThick)
+                {
+                    // Thick wall. Offset vertices and evaluate 
+
+                    var wallVec = new Vector2(to.XPos - from.XPos, to.YPos - from.YPos);
+
+                    wallVec.Normalize();
+                    var thickVec = wallVec * Thickness;
+
+                    var offsetR = new Vector3(-thickVec.y, 0, thickVec.x);
+                    var offsetL = new Vector3(thickVec.y, 0, -thickVec.x);
+
+                    WallIntersectionMember fromMember = fromI.IncomingLines.First(x => x.WallID == i);
+                    WallIntersectionMember toMember = toI.IncomingLines.First(x => x.WallID == i);
+
+                    var offsetLStart = offsetL + new Vector3(wallVec.x * fromMember.LeftExtent * -1, 0, wallVec.y * fromMember.LeftExtent * -1);
+                    var offsetRStart = offsetR + new Vector3(wallVec.x * fromMember.RightExtent * -1, 0, wallVec.y * fromMember.RightExtent * -1);
+
+                    var offsetLEnd = offsetL + new Vector3(wallVec.x * toMember.LeftExtent, 0, wallVec.y * toMember.LeftExtent);
+                    var offsetREnd = offsetR + new Vector3(wallVec.x * toMember.RightExtent, 0, wallVec.y * toMember.RightExtent);
+
+                    thicknessVerts[4] = wallVertices[3]; // Center Start
+                    thicknessVerts[5] = wallVertices[2]; // Center End
+                    
+                    wallVertices2[0] = wallVertices[0] + offsetRStart;
+                    wallVertices2[1] = wallVertices[1] + offsetREnd;
+                    wallVertices2[2] = wallVertices[2] + offsetREnd;
+                    wallVertices2[3] = wallVertices[3] + offsetRStart;
+
+                    wallVertices[0] += offsetLStart;
+                    wallVertices[1] += offsetLEnd;
+                    wallVertices[2] += offsetLEnd;
+                    wallVertices[3] += offsetLStart;
+
+                    // Add wall thickness
+
+                    thicknessVerts[0] = wallVertices[3]; // L top start
+                    thicknessVerts[1] = wallVertices[2]; // L top end
+                    thicknessVerts[2] = wallVertices2[2]; // R top end
+                    thicknessVerts[3] = wallVertices2[3]; // R top start
+
+                    for (int j = 0; j < 6; j++)
+                    {
+                        thicknessUVs[j] = new Vector2(thicknessVerts[j].x, 0);
+                    }
+
+                    int thicknessBase = thicknessComp.GetVertexIndex();
+                    thicknessComp.AddVertices(thicknessVerts, thicknessUVs);
+
+                    thicknessComp.AddIndex(thicknessBase + 1);
+                    thicknessComp.AddIndex(thicknessBase);
+                    thicknessComp.AddIndex(thicknessBase + 2);
+
+                    thicknessComp.AddIndex(thicknessBase + 3);
+                    thicknessComp.AddIndex(thicknessBase + 2);
+                    thicknessComp.AddIndex(thicknessBase);
+
+                    // Ends
+                    thicknessComp.AddIndex(thicknessBase + 5);
+                    thicknessComp.AddIndex(thicknessBase + 1);
+                    thicknessComp.AddIndex(thicknessBase + 2);
+
+                    thicknessComp.AddIndex(thicknessBase + 4);
+                    thicknessComp.AddIndex(thicknessBase + 3);
+                    thicknessComp.AddIndex(thicknessBase);
+                }
+
+                if (lPattern != null)
+                {
+                    var lVertStart = lPattern.GetVertexIndex();
+                    lPattern.AddVertices(wallVertices, wallUVs);
+
+                    lPattern.AddIndex(lVertStart);
+                    lPattern.AddIndex(lVertStart + 3);
+                    lPattern.AddIndex(lVertStart + 2);
+
+                    lPattern.AddIndex(lVertStart + 2);
+                    lPattern.AddIndex(lVertStart + 1);
+                    lPattern.AddIndex(lVertStart + 0);
+                }
+
+                if (rPattern != null)
+                {
+                    var rVertStart = rPattern.GetVertexIndex();
+                    rPattern.AddVertices(isThick ? wallVertices2 : wallVertices, wallUVs);
+
+                    rPattern.AddIndex(rVertStart);
+                    rPattern.AddIndex(rVertStart + 1);
+                    rPattern.AddIndex(rVertStart + 2);
+
+                    rPattern.AddIndex(rVertStart + 2);
+                    rPattern.AddIndex(rVertStart + 3);
+                    rPattern.AddIndex(rVertStart);
+                }
+            }
+
+            foreach (PatternMesh pattern in _patterns)
+            {
+                pattern?.Component.Commit();
+            }
+
+            thicknessComp.Commit();
+        }
+
+        private void AddFencePosts()
+        {
+            int width = _elevationData.Width;
+            int height = _elevationData.Height;
+            int floors = _elevationData.Depth;
+            int baseFloor = _wallGraph.BaseFloor;
+
+            FencePost[] entries = _fencePosts.Entries;
+
+            for (int i = 0; i < entries.Length; i++)
+            {
+                ref FencePost entry = ref entries[i];
+
+                var fence = GetFence(entry.GUID);
+
+                fence.AddPost(entry.XPos, entry.YPos, GetElevationInt(_elevationData.Data[entry.Level - baseFloor], width, height, entry.XPos, entry.YPos));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -256,7 +256,8 @@ namespace OpenTS2.Scenes.Lot
 
             if (wallGraph.Floors != elevationData.Depth)
             {
-                throw new InvalidOperationException("Size mismatch between elevation and wall graph");
+                // Apparently these are allowed to disagree?
+                // throw new InvalidOperationException("Size mismatch between elevation and wall graph");
             }
 
             LoadPatterns();

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -34,6 +34,7 @@ namespace OpenTS2.Scenes.Lot
         private const string FallbackMaterial = "wall_wallboard";
         private const float HalfWallHeight = 1f;
         private const float WallHeight = 3f;
+        private const float YBias = 0.001f;
         private const float Thickness = 0.075f;
         private const float RoofOffset = Thickness * 2.5f;
 
@@ -42,6 +43,7 @@ namespace OpenTS2.Scenes.Lot
             { "blank", FallbackMaterial },
             { "deckskirtminimal", null },
             { "foundationbrick", "wall_brick_base" },
+            { "deckredwood", "wall_deckredwoodb_base" },
             { "wall_poolroundedlipblue", "wall_poolroundedlipblue_base" }
         };
 
@@ -272,6 +274,8 @@ namespace OpenTS2.Scenes.Lot
             BuildWallIntersections();
             BuildWallMeshes();
             AddFencePosts();
+
+            gameObject.transform.position = new Vector3(0, -YBias, 0);
         }
 
         private ScenegraphMaterialDefinitionAsset LoadMaterial(ContentProvider contentProvider, string name)
@@ -357,6 +361,21 @@ namespace OpenTS2.Scenes.Lot
                 case WallType.Pool:
                 case WallType.OFBWall:
                     return true;
+                default:
+                    return false;
+            }
+        }
+
+        private bool IsDeck(int type)
+        {
+            switch (type)
+            {
+                case WallType.Deck:
+                case WallType.Deck2:
+                case WallType.Deck3:
+                case WallType.DeckInvis:
+                    return true;
+
                 default:
                     return false;
             }
@@ -651,6 +670,21 @@ namespace OpenTS2.Scenes.Lot
                 wallUVs[5] = new Vector2(0, bottomUVs ? (1 - startUV) : 0);
 
                 bool isThick = IsWallThick(layerElem);
+
+
+                if (!isThick && IsDeck(layerElem.WallType))
+                {
+                    float floorThickness = LotFloorComponent.Thickness - YBias;
+                    float floorThicknessUV = floorThickness / WallHeight;
+
+                    wallVertices[3].y -= floorThickness;
+                    wallVertices[4].y -= floorThickness;
+                    wallVertices[5].y -= floorThickness;
+
+                    wallUVs[3].y += floorThicknessUV;
+                    wallUVs[4].y += floorThicknessUV;
+                    wallUVs[5].y += floorThicknessUV;
+                }
 
                 if (isThick)
                 {

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -508,6 +508,7 @@ namespace OpenTS2.Scenes.Lot
 
             Vector3[] wallVertices = new Vector3[4];
             Vector3[] wallVertices2 = new Vector3[4];
+            Vector3[] endVertices = new Vector3[4];
             Vector2[] wallUVs = new Vector2[4];
 
             Vector3[] thicknessVerts = new Vector3[6];
@@ -620,7 +621,7 @@ namespace OpenTS2.Scenes.Lot
 
                     for (int j = 0; j < 6; j++)
                     {
-                        thicknessUVs[j] = new Vector2(thicknessVerts[j].x, 0);
+                        thicknessUVs[j] = new Vector2(0, thicknessVerts[j].z);
                     }
 
                     int thicknessBase = thicknessComp.GetVertexIndex();
@@ -660,6 +661,11 @@ namespace OpenTS2.Scenes.Lot
 
                 if (rPattern != null)
                 {
+                    wallUVs[0].x = 1;
+                    wallUVs[1].x = 0;
+                    wallUVs[2].x = 0;
+                    wallUVs[3].x = 1;
+
                     var rVertStart = rPattern.GetVertexIndex();
                     rPattern.AddVertices(isThick ? wallVertices2 : wallVertices, wallUVs);
 
@@ -670,6 +676,59 @@ namespace OpenTS2.Scenes.Lot
                     rPattern.AddIndex(rVertStart + 2);
                     rPattern.AddIndex(rVertStart + 3);
                     rPattern.AddIndex(rVertStart);
+                }
+
+                // Cap off wall ends.
+                if (toI.Simple && toI.IncomingLines.Count == 1)
+                {
+                    float bottomV = (wallVertices[2].y - wallVertices[1].y) / WallHeight;
+
+                    endVertices[0] = wallVertices[1];
+                    endVertices[1] = wallVertices2[1];
+                    endVertices[2] = wallVertices2[2];
+                    endVertices[3] = wallVertices[2];
+
+                    wallUVs[0] = new Vector2(1 - Thickness * 2, bottomV);
+                    wallUVs[1] = new Vector2(1, bottomV);
+                    wallUVs[2] = new Vector2(1, 0);
+                    wallUVs[3] = new Vector2(1 - Thickness * 2, 0);
+
+                    var rVertStart = rPattern.GetVertexIndex();
+                    rPattern.AddVertices(endVertices, wallUVs);
+
+                    rPattern.AddIndex(rVertStart);
+                    rPattern.AddIndex(rVertStart + 3);
+                    rPattern.AddIndex(rVertStart + 2);
+
+                    rPattern.AddIndex(rVertStart + 2);
+                    rPattern.AddIndex(rVertStart + 1);
+                    rPattern.AddIndex(rVertStart + 0);
+                }
+
+                if (fromI.Simple && fromI.IncomingLines.Count == 1)
+                {
+                    float bottomV = (wallVertices[3].y - wallVertices[0].y) / WallHeight;
+
+                    endVertices[0] = wallVertices2[0];
+                    endVertices[1] = wallVertices[0];
+                    endVertices[2] = wallVertices[3];
+                    endVertices[3] = wallVertices2[3];
+
+                    wallUVs[0] = new Vector2(1 - Thickness * 2, bottomV);
+                    wallUVs[1] = new Vector2(1, bottomV);
+                    wallUVs[2] = new Vector2(1, 0);
+                    wallUVs[3] = new Vector2(1 - Thickness * 2, 0);
+
+                    var lVertStart = lPattern.GetVertexIndex();
+                    lPattern.AddVertices(endVertices, wallUVs);
+
+                    lPattern.AddIndex(lVertStart);
+                    lPattern.AddIndex(lVertStart + 3);
+                    lPattern.AddIndex(lVertStart + 2);
+
+                    lPattern.AddIndex(lVertStart + 2);
+                    lPattern.AddIndex(lVertStart + 1);
+                    lPattern.AddIndex(lVertStart + 0);
                 }
             }
 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -597,9 +597,9 @@ namespace OpenTS2.Scenes.Lot
 
                 if (roofWall)
                 {
-                    heightTo = Mathf.Max(_roofs.GetHeightAt(to.XPos, to.YPos, heightTo, RoofOffset), floorTo);
-                    heightMid = Mathf.Max(_roofs.GetHeightAt(midX, midY, heightMid, RoofOffset), floorMid);
-                    heightFrom = Mathf.Max(_roofs.GetHeightAt(from.XPos, from.YPos, heightFrom, RoofOffset), floorFrom);
+                    heightTo = Mathf.Max(_roofs.GetHeightAt(to.XPos, to.YPos, from.Level, heightTo, RoofOffset), floorTo);
+                    heightMid = Mathf.Max(_roofs.GetHeightAt(midX, midY, from.Level, heightMid, RoofOffset), floorMid);
+                    heightFrom = Mathf.Max(_roofs.GetHeightAt(from.XPos, from.YPos, from.Level, heightFrom, RoofOffset), floorFrom);
                 }
 
                 wallVertices[3] = new Vector3(to.XPos, heightTo, to.YPos);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -597,9 +597,9 @@ namespace OpenTS2.Scenes.Lot
 
                 if (roofWall)
                 {
-                    heightTo = Mathf.Max(_roofs.GetHeightAt(to.XPos, to.YPos, heightTo) - RoofOffset, floorTo);
-                    heightMid = Mathf.Max(_roofs.GetHeightAt(midX, midY, heightTo) - RoofOffset, floorMid);
-                    heightFrom = Mathf.Max(_roofs.GetHeightAt(from.XPos, from.YPos, heightTo) - RoofOffset, floorFrom);
+                    heightTo = Mathf.Max(_roofs.GetHeightAt(to.XPos, to.YPos, heightTo, RoofOffset), floorTo);
+                    heightMid = Mathf.Max(_roofs.GetHeightAt(midX, midY, heightMid, RoofOffset), floorMid);
+                    heightFrom = Mathf.Max(_roofs.GetHeightAt(from.XPos, from.YPos, heightFrom, RoofOffset), floorFrom);
                 }
 
                 wallVertices[3] = new Vector3(to.XPos, heightTo, to.YPos);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs
@@ -318,12 +318,14 @@ namespace OpenTS2.Scenes.Lot
 
                 var material = LoadMaterial(contentProvider, materialName);
 
-                if (material == null)
+                try
                 {
-
+                    _patterns[entry.Id] = material == null ? null : new PatternMesh(gameObject, materialName, material?.GetAsUnityMaterial());
                 }
-
-                _patterns[entry.Id] = material == null ? null : new PatternMesh(gameObject, materialName, material?.GetAsUnityMaterial());
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
 
             _thickness = new PatternMesh(gameObject, ThicknessTexture, LoadMaterial(contentProvider, ThicknessTexture).GetAsUnityMaterial());

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/LotWallComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bbfe0a3e8ac1c149ac15a7e22b014c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public class PatternMesh
+    {
+        public GameObject Object;
+        public LotFloorPatternComponent Component;
+
+        public PatternMesh(GameObject parent, string name, Material material)
+        {
+            Object = new GameObject(name, typeof(LotFloorPatternComponent));
+            Component = Object.GetComponent<LotFloorPatternComponent>();
+
+            Object.transform.SetParent(parent.transform);
+            Component.Initialize(material);
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
@@ -5,12 +5,12 @@ namespace OpenTS2.Scenes.Lot
     public class PatternMesh
     {
         public GameObject Object;
-        public LotFloorPatternComponent Component;
+        public LotArchitectureMeshComponent Component;
 
         public PatternMesh(GameObject parent, string name, Material material)
         {
-            Object = new GameObject(name, typeof(LotFloorPatternComponent));
-            Component = Object.GetComponent<LotFloorPatternComponent>();
+            Object = new GameObject(name, typeof(LotArchitectureMeshComponent));
+            Component = Object.GetComponent<LotArchitectureMeshComponent>();
 
             Object.transform.SetParent(parent.transform);
             Component.Initialize(material);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs
@@ -1,3 +1,5 @@
+using OpenTS2.Scenes.Lot.State;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace OpenTS2.Scenes.Lot
@@ -7,13 +9,79 @@ namespace OpenTS2.Scenes.Lot
         public GameObject Object;
         public LotArchitectureMeshComponent Component;
 
-        public PatternMesh(GameObject parent, string name, Material material)
+        private string _name;
+        private Material _material;
+        private Dictionary<Texture2D, PatternMesh> _maskMeshes;
+
+        public PatternMesh(GameObject parent, string name, Material material, bool extraUV = false)
         {
+            _name = name;
+            _material = material;
+
             Object = new GameObject(name, typeof(LotArchitectureMeshComponent));
             Component = Object.GetComponent<LotArchitectureMeshComponent>();
 
+            if (extraUV)
+            {
+                Component.EnableExtraUV();
+            }
+
             Object.transform.SetParent(parent.transform);
             Component.Initialize(material);
+        }
+
+        public PatternMesh GetForMask(Texture2D mask)
+        {
+            _maskMeshes ??= new Dictionary<Texture2D, PatternMesh>();
+
+            if (!_maskMeshes.TryGetValue(mask, out PatternMesh mesh))
+            {
+                Material material = new Material(_material);
+
+                // TODO: Bind the mask as a mask texture.
+
+                mesh = new PatternMesh(Object, $"{_name}_mask_{mask.GetHashCode():x8}", material);
+            }
+
+            return mesh;
+        }
+
+        public void Clear()
+        {
+            Component.Clear();
+
+            if (_maskMeshes != null)
+            {
+                foreach (PatternMesh pattern in _maskMeshes.Values)
+                {
+                    pattern.Clear();
+                }
+            }
+        }
+
+        public bool Commit()
+        {
+            // TODO: Eventually, committing an empty mesh should delete the game object for that pattern/component.
+
+            bool hasData = false;
+
+            hasData |= Component.Commit();
+
+            if (_maskMeshes != null)
+            {
+                foreach (PatternMesh pattern in _maskMeshes.Values)
+                {
+                    hasData |= pattern.Commit();
+                }
+            }
+
+            return hasData;
+        }
+
+        public void UpdateDisplay(WorldState state, bool visible, bool isTop)
+        {
+            // TODO: Walls cutaway
+            Component.SetVisible(visible);
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMesh.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f5e996a9a6ec4143b26de7d5a687dd8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs
@@ -18,12 +18,14 @@ namespace OpenTS2.Scenes.Lot
         private PatternVariant[] _variants;
 
         private PatternMeshFloor[] _floors;
+        private IPatternMaterialConfigurator _matConfig;
 
-        public PatternMeshCollection(GameObject parent, PatternDescriptor[] patterns, PatternVariant[] variants, int floorCount)
+        public PatternMeshCollection(GameObject parent, PatternDescriptor[] patterns, PatternVariant[] variants, IPatternMaterialConfigurator matConfig, int floorCount)
         {
             _parent = parent;
             _patterns = patterns;
             _variants = variants;
+            _matConfig = matConfig;
 
             _floors = new PatternMeshFloor[floorCount];
         }
@@ -42,7 +44,7 @@ namespace OpenTS2.Scenes.Lot
 
             if (result == null)
             {
-                result = new PatternMeshFloor(_parent, floor, _variants, _patterns);
+                result = new PatternMeshFloor(_parent, floor, _variants, _patterns, _matConfig);
 
                 _floors[floor] = result;
             }
@@ -88,11 +90,6 @@ namespace OpenTS2.Scenes.Lot
                 {
                     topLevel = -1;
                 }
-            }
-            else if (type == DisplayUpdateType.Wall && state.Walls < WallsMode.Up)
-            {
-                // Temporary - the vertex shader should be doing this.
-                topLevel--;
             }
 
             for (int i = 0; i < _floors.Length; i++)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs
@@ -1,0 +1,108 @@
+using OpenTS2.Scenes.Lot.State;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public enum DisplayUpdateType
+    {
+        Default,
+        Roof,
+        Wall
+    }
+
+    public struct PatternMeshCollection
+    {
+        private GameObject _parent;
+        private PatternDescriptor[] _patterns;
+        private PatternVariant[] _variants;
+
+        private PatternMeshFloor[] _floors;
+
+        public PatternMeshCollection(GameObject parent, PatternDescriptor[] patterns, PatternVariant[] variants, int floorCount)
+        {
+            _parent = parent;
+            _patterns = patterns;
+            _variants = variants;
+
+            _floors = new PatternMeshFloor[floorCount];
+        }
+
+        public void SetFloorCount(int floorCount)
+        {
+            if (_floors.Length != floorCount)
+            {
+                Array.Resize(ref _floors, floorCount);
+            }
+        }
+
+        public PatternMeshFloor GetFloor(int floor)
+        {
+            PatternMeshFloor result = _floors[floor];
+
+            if (result == null)
+            {
+                result = new PatternMeshFloor(_parent, floor, _variants, _patterns);
+
+                _floors[floor] = result;
+            }
+
+            return result;
+        }
+
+        public void UpdatePatterns(PatternDescriptor[] patterns)
+        {
+            foreach (var floor in _floors)
+            {
+                floor?.UpdatePatterns(patterns);
+            }
+        }
+
+        public void ClearAll()
+        {
+            foreach (PatternMeshFloor floor in _floors)
+            {
+                floor?.Clear();
+            }
+        }
+
+        public bool CommitAll()
+        {
+            bool hasData = false;
+
+            foreach (PatternMeshFloor floor in _floors)
+            {
+                hasData |= floor?.Commit() ?? false;
+            }
+
+            return hasData;
+        }
+
+        public void UpdateDisplay(WorldState state, int baseLevel, DisplayUpdateType type = DisplayUpdateType.Default)
+        {
+            int topLevel = state.Level - baseLevel;
+
+            if (type == DisplayUpdateType.Roof)
+            {
+                if (state.Walls != WallsMode.Roof)
+                {
+                    topLevel = -1;
+                }
+            }
+            else if (type == DisplayUpdateType.Wall && state.Walls < WallsMode.Up)
+            {
+                // Temporary - the vertex shader should be doing this.
+                topLevel--;
+            }
+
+            for (int i = 0; i < _floors.Length; i++)
+            {
+                bool visible = i < topLevel;
+                bool isTop = i == topLevel - 1;
+
+                _floors[i]?.UpdateDisplay(state, visible, isTop);
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b984f18a1978ac4f816fe2c2f89918f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs
@@ -22,13 +22,11 @@ namespace OpenTS2.Scenes.Lot
     {
         public readonly string Name;
         public readonly Func<Material, Material> MaterialTransform;
-        public readonly bool ExtraUV;
 
-        public PatternVariant(string name, Func<Material, Material> materialTransform = null, bool extraUV = false)
+        public PatternVariant(string name, Func<Material, Material> materialTransform = null)
         {
             Name = name;
             MaterialTransform = materialTransform;
-            ExtraUV = extraUV;
         }
     }
 
@@ -44,12 +42,15 @@ namespace OpenTS2.Scenes.Lot
 
         private Dictionary<uint, FenceCollection> _fenceByGuid;
 
-        public PatternMeshFloor(GameObject parent, int id, PatternVariant[] variants, PatternDescriptor[] patterns)
+        private IPatternMaterialConfigurator _matConfig;
+
+        public PatternMeshFloor(GameObject parent, int id, PatternVariant[] variants, PatternDescriptor[] patterns, IPatternMaterialConfigurator matConfig)
         {
             Object = new GameObject($"Floor {id}");
             Object.transform.SetParent(parent.transform);
 
             _variants = variants;
+            _matConfig = matConfig;
 
             UpdatePatterns(patterns);
         }
@@ -87,11 +88,11 @@ namespace OpenTS2.Scenes.Lot
                         Object,
                         $"{descriptor.Name}_{variant.Name}",
                         variant.MaterialTransform != null ? variant.MaterialTransform(descriptor.Material) : descriptor.Material,
-                        variant.ExtraUV);
+                        _matConfig);
                 }
                 else
                 {
-                    result = new PatternMesh(Object, descriptor.Name, descriptor.Material);
+                    result = new PatternMesh(Object, descriptor.Name, descriptor.Material, _matConfig);
                 }
 
                 _patternMeshes[key] = result;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs
@@ -1,0 +1,161 @@
+using OpenTS2.Content;
+using OpenTS2.Scenes.Lot.State;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot
+{
+    public readonly struct PatternDescriptor
+    {
+        public readonly string Name;
+        public readonly Material Material;
+
+        public PatternDescriptor(string name, Material material)
+        {
+            Name = name;
+            Material = material;
+        }
+    }
+
+    public readonly struct PatternVariant
+    {
+        public readonly string Name;
+        public readonly Func<Material, Material> MaterialTransform;
+        public readonly bool ExtraUV;
+
+        public PatternVariant(string name, Func<Material, Material> materialTransform = null, bool extraUV = false)
+        {
+            Name = name;
+            MaterialTransform = materialTransform;
+            ExtraUV = extraUV;
+        }
+    }
+
+    public class PatternMeshFloor
+    {
+        public GameObject Object;
+
+        private PatternVariant[] _variants;
+
+        private PatternDescriptor[] _patterns;
+
+        private PatternMesh[] _patternMeshes;
+
+        private Dictionary<uint, FenceCollection> _fenceByGuid;
+
+        public PatternMeshFloor(GameObject parent, int id, PatternVariant[] variants, PatternDescriptor[] patterns)
+        {
+            Object = new GameObject($"Floor {id}");
+            Object.transform.SetParent(parent.transform);
+
+            _variants = variants;
+
+            UpdatePatterns(patterns);
+        }
+
+        public void UpdatePatterns(PatternDescriptor[] patterns)
+        {
+            _patterns = patterns;
+
+            _patternMeshes = new PatternMesh[patterns.Length * (1 + _variants.Length)];
+        }
+
+        public PatternMesh Get(int id, int variantId = 0)
+        {
+            int key = id + variantId * _patterns.Length;
+
+            PatternMesh result = _patternMeshes[key];
+
+            if (result == null)
+            {
+                // Make a new one.
+
+                ref var descriptor = ref _patterns[id];
+
+                if (descriptor.Material == null)
+                {
+                    // Never mind.
+                    return null;
+                }
+
+                if (variantId > 0)
+                {
+                    ref var variant = ref _variants[variantId - 1];
+
+                    result = new PatternMesh(
+                        Object,
+                        $"{descriptor.Name}_{variant.Name}",
+                        variant.MaterialTransform != null ? variant.MaterialTransform(descriptor.Material) : descriptor.Material,
+                        variant.ExtraUV);
+                }
+                else
+                {
+                    result = new PatternMesh(Object, descriptor.Name, descriptor.Material);
+                }
+
+                _patternMeshes[key] = result;
+            }
+
+            return result;
+        }
+
+        public FenceCollection GetFence(uint guid)
+        {
+            _fenceByGuid ??= new Dictionary<uint, FenceCollection>();
+
+            if (!_fenceByGuid.TryGetValue(guid, out FenceCollection result))
+            {
+                result = new FenceCollection(ContentProvider.Get(), Object, guid);
+
+                _fenceByGuid[guid] = result;
+            }
+
+            return result;
+        }
+
+        public void Clear()
+        {
+            foreach (PatternMesh pattern in _patternMeshes)
+            {
+                pattern?.Clear();
+            }
+
+            if (_fenceByGuid != null)
+            {
+                foreach (FenceCollection fences in _fenceByGuid.Values)
+                {
+                    fences.Clear();
+                }
+            }
+        }
+
+        public bool Commit()
+        {
+            bool hasData = false;
+
+            foreach (PatternMesh pattern in _patternMeshes)
+            {
+                hasData |= pattern?.Commit() ?? false;
+            }
+
+            return hasData;
+        }
+
+        public void UpdateDisplay(WorldState state, bool visible, bool isTop)
+        {
+            foreach (PatternMesh pattern in _patternMeshes)
+            {
+                pattern?.UpdateDisplay(state, visible, isTop);
+            }
+
+            if (_fenceByGuid != null)
+            {
+                foreach (FenceCollection fences in _fenceByGuid.Values)
+                {
+                    fences.SetVisible(visible);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/PatternMeshFloor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a2cadef9bf7dc8469ed31a4018bb400
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79092ab5cefa0cd4da2fd78d6eed5418
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
@@ -1,0 +1,61 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public abstract class AbstractSimpleRoof : IRoofType
+    {
+        public RoofEntry RoofEntry => _entry;
+
+        private RoofEntry _entry;
+
+        protected float Height;
+        protected RoofEdge[] Edges;
+
+        public AbstractSimpleRoof(RoofEntry entry, float height)
+        {
+            _entry = entry;
+            Height = height;
+        }
+
+        public float GetHeightAt(float x, float y)
+        {
+            foreach (var edge in Edges)
+            {
+                float result = edge.GetHeightAt(x, y);
+
+                if (result != float.PositiveInfinity)
+                {
+                    return result;
+                }
+            }
+
+            return float.PositiveInfinity;
+        }
+
+        public void GenerateGeometry(RoofGeometryCollection geo)
+        {
+            foreach (var edge in Edges)
+            {
+                edge.GenerateGeometry(geo);
+            }
+        }
+
+        public static int DetermineDirectionCardinal(in RoofEntry roof)
+        {
+            var vec = new Vector2(roof.XTo - roof.XFrom, roof.YTo - roof.YFrom);
+
+            if (Math.Abs(vec.y) > Math.Abs(vec.x))
+            {
+                // Generally pointing in the X direction
+                return vec.x > 0 ? 0 : 2;
+            }
+            else
+            {
+                // Generally pointing in the Y direction
+                return vec.y > 0 ? 1 : 3;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
@@ -42,7 +42,21 @@ namespace OpenTS2.Scenes.Lot.Roof
             }
         }
 
-        public static int DetermineDirectionCardinal(in RoofEntry roof)
+        protected static int DetermineDirection(Vector2 vec)
+        {
+            if (Math.Abs(vec.y) > Math.Abs(vec.x))
+            {
+                // Generally pointing in the X direction
+                return vec.x > 0 ? 0 : 2;
+            }
+            else
+            {
+                // Generally pointing in the Y direction
+                return vec.y > 0 ? 1 : 3;
+            }
+        }
+
+        protected static int DetermineDirectionCardinal(in RoofEntry roof)
         {
             var vec = new Vector2(roof.XTo - roof.XFrom, roof.YTo - roof.YFrom);
 
@@ -56,6 +70,45 @@ namespace OpenTS2.Scenes.Lot.Roof
                 // Generally pointing in the Y direction
                 return vec.y > 0 ? 1 : 3;
             }
+        }
+
+        protected static Vector2 GetDiagonalVector(in RoofEntry roof)
+        {
+            var vec = new Vector2(roof.XTo - roof.XFrom, roof.YTo - roof.YFrom);
+
+            // Vector is composed of two components: (1, 1)*xD + (-1, 1)*yD = vec
+            // vec.x = xD - yD
+            // vec.y = xD + yD
+            // Try and find those components.
+
+            // vec.x = (vec.y - yD) - yD
+            // vec.x = vec.y - 2yD
+            // yD = (vec.y - vec.x) / 2
+
+            float yD = (vec.y - vec.x) / 2;
+            float xD = vec.y - yD;
+
+            return new Vector2(xD, yD);
+        }
+
+        protected static Vector2 VectorFromDiagonal(Vector2 diag)
+        {
+            return new Vector2(diag.x - diag.y, diag.x + diag.y);
+        }
+
+        protected static Vector2 RotateVector(Vector2 vec, int dir)
+        {
+            switch (dir)
+            {
+                case 1:
+                    return new Vector2(-vec.y, vec.x);
+                case 2:
+                    return new Vector2(-vec.x, -vec.y);
+                case 3:
+                    return new Vector2(vec.y, -vec.x);
+            }
+
+            return vec;
         }
 
         public void Intersect(IRoofType other)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs
@@ -57,5 +57,30 @@ namespace OpenTS2.Scenes.Lot.Roof
                 return vec.y > 0 ? 1 : 3;
             }
         }
+
+        public void Intersect(IRoofType other)
+        {
+            if ((other is AbstractSimpleRoof roof))
+            {
+                foreach (var edge in Edges)
+                {
+                    foreach (var oedge in roof.Edges)
+                    {
+                        if (!edge.Intersect(oedge))
+                        {
+                            edge.RemoveTilesUnder(other);
+                            oedge.RemoveTilesUnder(this);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var edge in Edges)
+                {
+                    edge.RemoveTilesUnder(other);
+                }
+            }
+        }
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/AbstractSimpleRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24966fb2debb22648afab1fe0f7d4be8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class DiagonalGableRoof : AbstractSimpleRoof
     {
-        public DiagonalGableRoof(RoofEntry entry, float height, bool isLong) : base(entry, height)
+        public DiagonalGableRoof(RoofEntry entry, float height, bool isLong, bool pagoda = false) : base(entry, height)
         {
             Vector2 diagVec = GetDiagonalVector(entry);
             int dir = DetermineDirection(diagVec);
@@ -32,8 +32,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
-                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda)
                 };
             }
             else
@@ -42,8 +42,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
-                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
+                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda)
                 };
             }
         }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs
@@ -1,0 +1,51 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class DiagonalGableRoof : AbstractSimpleRoof
+    {
+        public DiagonalGableRoof(RoofEntry entry, float height, bool isLong) : base(entry, height)
+        {
+            Vector2 diagVec = GetDiagonalVector(entry);
+            int dir = DetermineDirection(diagVec);
+
+            Vector2 from = new Vector2(entry.XFrom, entry.YFrom);
+
+            float minX = Math.Min(0, diagVec.x);
+            float maxX = Math.Max(0, diagVec.x);
+            float minY = Math.Min(0, diagVec.y);
+            float maxY = Math.Max(0, diagVec.y);
+
+            Vector2 bl = from + VectorFromDiagonal(new Vector2(minX, minY));
+            Vector2 tr = from + VectorFromDiagonal(new Vector2(maxX, maxY));
+            Vector2 br = from + VectorFromDiagonal(new Vector2(maxX, minY));
+            Vector2 tl = from + VectorFromDiagonal(new Vector2(minX, maxY));
+
+            bool flatInX = (dir % 2) == (isLong ? 1 : 0);
+            float slope = entry.RoofAngle;
+
+            if (flatInX)
+            {
+                Vector2 toTop = VectorFromDiagonal(new Vector2(0, (maxY - minY) / 2));
+
+                Edges = new RoofEdge[]
+                {
+                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                };
+            }
+            else
+            {
+                Vector2 toTop = VectorFromDiagonal(new Vector2((maxX - minX) / 2, 0));
+
+                Edges = new RoofEdge[]
+                {
+                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                };
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalGableRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a976e60d050cf4249945554847acf5e4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs
@@ -1,0 +1,40 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class DiagonalHipRoof : AbstractSimpleRoof
+    {
+        public DiagonalHipRoof(RoofEntry entry, float height) : base(entry, height)
+        {
+            Vector2 size = GetDiagonalVector(entry);
+            Vector2 from = new Vector2(entry.XFrom, entry.YFrom);
+
+            float lowX = Math.Min(0, size.x);
+            float hiX = Math.Max(0, size.x);
+            float lowY = Math.Min(0, size.y);
+            float hiY = Math.Max(0, size.y);
+
+            Vector2 bl = from + VectorFromDiagonal(new Vector2(lowX, lowY));
+            Vector2 tr = from + VectorFromDiagonal(new Vector2(hiX, hiY));
+            Vector2 br = from + VectorFromDiagonal(new Vector2(hiX, lowY));
+            Vector2 tl = from + VectorFromDiagonal(new Vector2(lowX, hiY));
+
+            float minDim = Math.Min(Math.Abs(size.x), Math.Abs(size.y)) / 2;
+
+            Vector2 minX = VectorFromDiagonal(new Vector2(minDim, 0));
+            Vector2 minY = VectorFromDiagonal(new Vector2(0, minDim));
+
+            float slope = entry.RoofAngle;
+
+            Edges = new RoofEdge[]
+            {
+                new RoofEdge(height, slope, bl, br, br + minY, bl + minY), // Bottom
+                new RoofEdge(height, slope, br, tr, tr - minX, br - minX), // Right
+                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY), // Top
+                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX), // Left
+            };
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class DiagonalHipRoof : AbstractSimpleRoof
     {
-        public DiagonalHipRoof(RoofEntry entry, float height) : base(entry, height)
+        public DiagonalHipRoof(RoofEntry entry, float height, bool pagoda = false) : base(entry, height)
         {
             Vector2 size = GetDiagonalVector(entry);
             Vector2 from = new Vector2(entry.XFrom, entry.YFrom);
@@ -30,10 +30,10 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             Edges = new RoofEdge[]
             {
-                new RoofEdge(height, slope, bl, br, br + minY, bl + minY), // Bottom
-                new RoofEdge(height, slope, br, tr, tr - minX, br - minX), // Right
-                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY), // Top
-                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX), // Left
+                new RoofEdge(height, slope, bl, br, br + minY, bl + minY, pagoda: pagoda), // Bottom
+                new RoofEdge(height, slope, br, tr, tr - minX, br - minX, pagoda: pagoda), // Right
+                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY, pagoda: pagoda), // Top
+                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX, pagoda: pagoda), // Left
             };
         }
     }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalHipRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e7fcf2d8e045c1409bec2cd08b72857
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs
@@ -1,0 +1,64 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class DiagonalShedGableRoof : AbstractSimpleRoof
+    {
+        public DiagonalShedGableRoof(RoofEntry entry, float height) : base(entry, height)
+        {
+            Vector2 diagVec = GetDiagonalVector(entry);
+            int dir = DetermineDirection(diagVec);
+
+            Vector2 from = new Vector2(entry.XFrom, entry.YFrom);
+
+            float lowX = Math.Min(0, diagVec.x);
+            float hiX = Math.Max(0, diagVec.x);
+            float lowY = Math.Min(0, diagVec.y);
+            float hiY = Math.Max(0, diagVec.y);
+
+            Vector2 bl = from + VectorFromDiagonal(new Vector2(lowX, lowY));
+            Vector2 tr = from + VectorFromDiagonal(new Vector2(hiX, hiY));
+            Vector2 br = from + VectorFromDiagonal(new Vector2(hiX, lowY));
+            Vector2 tl = from + VectorFromDiagonal(new Vector2(lowX, hiY));
+
+            // "Towards" means that the wall edge is facing that direction.
+
+            // For some reason, diagonal normal shed roofs have a top overhang. None of the other shed roofs have this.
+            // The overhang has some weird properties. It has overhang rules for cutting out roofs below it,
+            // but it does alter wall height, which suggests it's physically present unlike other overhangs.
+            Vector2 overhang = VectorFromDiagonal(RotateVector(new Vector2(0.5f, 0), dir));
+
+            float slope = entry.RoofAngle;
+
+            switch (dir)
+            {
+                case 0: // Towards positive x
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, tl, bl, br + overhang, tr + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                    };
+                    break;
+                case 1: // Towards positive y
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, bl, br, tr + overhang, tl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                    };
+                    break;
+                case 2: // Towards negative x
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, br, tr, tl + overhang, bl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                    };
+                    break;
+                case 3: // Towards negative y
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, tr, tl, bl + overhang, br + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                    };
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class DiagonalShedGableRoof : AbstractSimpleRoof
     {
-        public DiagonalShedGableRoof(RoofEntry entry, float height) : base(entry, height)
+        public DiagonalShedGableRoof(RoofEntry entry, float height, bool pagoda = false) : base(entry, height)
         {
             Vector2 diagVec = GetDiagonalVector(entry);
             int dir = DetermineDirection(diagVec);
@@ -28,7 +28,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             // For some reason, diagonal normal shed roofs have a top overhang. None of the other shed roofs have this.
             // The overhang has some weird properties. It has overhang rules for cutting out roofs below it,
             // but it does alter wall height, which suggests it's physically present unlike other overhangs.
-            Vector2 overhang = VectorFromDiagonal(RotateVector(new Vector2(0.5f, 0), dir));
+            Vector2 overhang = pagoda ? new Vector2() : VectorFromDiagonal(RotateVector(new Vector2(0.5f, 0), dir));
 
             float slope = entry.RoofAngle;
 
@@ -37,25 +37,25 @@ namespace OpenTS2.Scenes.Lot.Roof
                 case 0: // Towards positive x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tl, bl, br + overhang, tr + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                        new RoofEdge(height, slope, tl, bl, br + overhang, tr + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2, pagoda: pagoda),
                     };
                     break;
                 case 1: // Towards positive y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, bl, br, tr + overhang, tl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                        new RoofEdge(height, slope, bl, br, tr + overhang, tl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2, pagoda: pagoda),
                     };
                     break;
                 case 2: // Towards negative x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, br, tr, tl + overhang, bl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                        new RoofEdge(height, slope, br, tr, tl + overhang, bl + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2, pagoda: pagoda),
                     };
                     break;
                 case 3: // Towards negative y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tr, tl, bl + overhang, br + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2),
+                        new RoofEdge(height, slope, tr, tl, bl + overhang, br + overhang, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, 2, pagoda: pagoda),
                     };
                     break;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedGableRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d8440dac1b85cd4e8ac30426731e04a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedHipRoof.cs
@@ -1,0 +1,59 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class DiagonalShedHipRoof : AbstractSimpleRoof
+    {
+        public DiagonalShedHipRoof(RoofEntry entry, float height) : base(entry, height)
+        {
+            Vector2 diagVec = GetDiagonalVector(entry);
+            int dir = DetermineDirection(diagVec);
+
+            Vector2 from = new Vector2(entry.XFrom, entry.YFrom);
+
+            float lowX = Math.Min(0, diagVec.x);
+            float hiX = Math.Max(0, diagVec.x);
+            float lowY = Math.Min(0, diagVec.y);
+            float hiY = Math.Max(0, diagVec.y);
+
+            Vector2 bl = from + VectorFromDiagonal(new Vector2(lowX, lowY));
+            Vector2 tr = from + VectorFromDiagonal(new Vector2(hiX, hiY));
+            Vector2 br = from + VectorFromDiagonal(new Vector2(hiX, lowY));
+            Vector2 tl = from + VectorFromDiagonal(new Vector2(lowX, hiY));
+
+            Vector2[] corners = new Vector2[]
+            {
+                tl, bl, br, tr
+            };
+
+            bool flatInX = ((dir % 2) == 0);
+
+            float minDim = flatInX ?
+                Math.Min(hiX - lowX, (hiY - lowY) / 2) : // In x direction
+                Math.Min((hiX - lowX) / 2, hiY - lowY);  // In y direction
+
+            Vector2 towardsDirection = VectorFromDiagonal(RotateVector(new Vector2(minDim, 0), dir));
+            Vector2 towardsTop = VectorFromDiagonal(RotateVector(new Vector2(0, minDim), dir));
+
+            Vector2 c1 = corners[dir];
+            Vector2 c2 = corners[(dir + 1) % 4];
+            Vector2 c3 = corners[(dir + 2) % 4];
+            Vector2 c4 = corners[(dir + 3) % 4];
+
+            // See gable roof for notes on this.
+            Vector2 overhang = VectorFromDiagonal(RotateVector(new Vector2(0.5f, 0), dir));
+            towardsDirection += overhang;
+
+            float slope = entry.RoofAngle;
+
+            Edges = new RoofEdge[]
+            {
+                new RoofEdge(height, slope, c4, c1, c1 - towardsTop, c4 - towardsTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Normal),
+                new RoofEdge(height, slope, c1, c2, c2 + towardsDirection, c1 + towardsDirection, topOverhangSize: 2),
+                new RoofEdge(height, slope, c2, c3, c3 + towardsTop, c2 + towardsTop, RoofEdgeEnd.Normal, RoofEdgeEnd.Flat),
+            };
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedHipRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/DiagonalShedHipRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7839643f0f2df441b32e73ce26b4247
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
@@ -1,0 +1,43 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class GableRoof : AbstractSimpleRoof
+    {
+        public GableRoof(RoofEntry entry, float height, bool isLong) : base(entry, height)
+        {
+            int dir = DetermineDirectionCardinal(entry);
+
+            Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
+            Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
+            Vector2 br = new Vector2(tr.x, bl.y);
+            Vector2 tl = new Vector2(bl.x, tr.y);
+
+            bool flatInX = (dir % 2) == (isLong ? 1 : 0);
+            float slope = entry.RoofAngle;
+
+            if (flatInX)
+            {
+                Vector2 toTop = new Vector2(0, (tr.y - br.y) / 2);
+
+                Edges = new RoofEdge[]
+                {
+                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, true, true),
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, br - toTop, true, true)
+                };
+            }
+            else
+            {
+                Vector2 toTop = new Vector2((tr.x - tl.x) / 2, 0);
+
+                Edges = new RoofEdge[]
+                {
+                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, true, true),
+                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, true, true)
+                };
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
@@ -24,8 +24,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, true, true),
-                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, true, true)
+                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
                 };
             }
             else
@@ -34,8 +34,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, true, true),
-                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, true, true)
+                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
                 };
             }
         }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
@@ -25,7 +25,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                 Edges = new RoofEdge[]
                 {
                     new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, true, true),
-                    new RoofEdge(height, slope, tr, tl, tl - toTop, br - toTop, true, true)
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, true, true)
                 };
             }
             else

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class GableRoof : AbstractSimpleRoof
     {
-        public GableRoof(RoofEntry entry, float height, bool isLong) : base(entry, height)
+        public GableRoof(RoofEntry entry, float height, bool isLong, bool pagoda = false) : base(entry, height)
         {
             int dir = DetermineDirectionCardinal(entry);
 
@@ -24,8 +24,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
-                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                    new RoofEdge(height, slope, bl, br, br + toTop, bl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
+                    new RoofEdge(height, slope, tr, tl, tl - toTop, tr - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda)
                 };
             }
             else
@@ -34,8 +34,8 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                 Edges = new RoofEdge[]
                 {
-                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
-                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat)
+                    new RoofEdge(height, slope, br, tr, tr - toTop, br - toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
+                    new RoofEdge(height, slope, tl, bl, bl + toTop, tl + toTop, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda)
                 };
             }
         }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/GableRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83528336e5fff824aa78db33c204eaae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs
@@ -1,0 +1,35 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class HipRoof : AbstractSimpleRoof
+    {
+        public HipRoof(RoofEntry entry, float height) : base(entry, height) 
+        {
+            Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
+            Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
+
+            Vector2 size = tr - bl;
+
+            float minDim = Math.Min(size.x, size.y) / 2;
+
+            Vector2 minX = new Vector2(minDim, 0);
+            Vector2 minY = new Vector2(0, minDim);
+
+            Vector2 br = new Vector2(tr.x, bl.y);
+            Vector2 tl = new Vector2(bl.x, tr.y);
+
+            float slope = entry.RoofAngle;
+
+            Edges = new RoofEdge[]
+            {
+                new RoofEdge(height, slope, bl, br, br + minY, bl + minY), // Bottom
+                new RoofEdge(height, slope, br, tr, tr - minX, br - minX), // Right
+                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY), // Top
+                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX), // Left
+            };
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class HipRoof : AbstractSimpleRoof
     {
-        public HipRoof(RoofEntry entry, float height) : base(entry, height) 
+        public HipRoof(RoofEntry entry, float height, bool pagoda = false) : base(entry, height) 
         {
             Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
             Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
@@ -25,10 +25,10 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             Edges = new RoofEdge[]
             {
-                new RoofEdge(height, slope, bl, br, br + minY, bl + minY), // Bottom
-                new RoofEdge(height, slope, br, tr, tr - minX, br - minX), // Right
-                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY), // Top
-                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX), // Left
+                new RoofEdge(height, slope, bl, br, br + minY, bl + minY, pagoda: pagoda), // Bottom
+                new RoofEdge(height, slope, br, tr, tr - minX, br - minX, pagoda: pagoda), // Right
+                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY, pagoda: pagoda), // Top
+                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX, pagoda: pagoda), // Left
             };
         }
     }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/HipRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f4dcccf25d7327419106eeffbe82077
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs
@@ -9,5 +9,7 @@ namespace OpenTS2.Scenes.Lot.Roof
         float GetHeightAt(float x, float y);
 
         void GenerateGeometry(RoofGeometryCollection geo);
+
+        public void Intersect(IRoofType other);
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs
@@ -1,0 +1,13 @@
+using OpenTS2.Content.DBPF;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public interface IRoofType
+    {
+        public RoofEntry RoofEntry { get; }
+
+        float GetHeightAt(float x, float y);
+
+        void GenerateGeometry(RoofGeometryCollection geo);
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/IRoofType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79db9d83083ab9744a0711e8937fd445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/MansardRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/MansardRoof.cs
@@ -1,0 +1,35 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class MansardRoof : AbstractSimpleRoof
+    {
+        public MansardRoof(RoofEntry entry, float height) : base(entry, height) 
+        {
+            Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
+            Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
+
+            Vector2 size = tr - bl;
+
+            float minDim = Math.Min(3, Math.Min(size.x, size.y) / 2);
+
+            Vector2 minX = new Vector2(minDim, 0);
+            Vector2 minY = new Vector2(0, minDim);
+
+            Vector2 br = new Vector2(tr.x, bl.y);
+            Vector2 tl = new Vector2(bl.x, tr.y);
+
+            float slope = entry.RoofAngle;
+
+            Edges = new RoofEdge[]
+            {
+                new RoofEdge(height, slope, bl, br, br + minY, bl + minY), // Bottom
+                new RoofEdge(height, slope, br, tr, tr - minX, br - minX), // Right
+                new RoofEdge(height, slope, tr, tl, tl - minY, tr - minY), // Top
+                new RoofEdge(height, slope, tl, bl, bl + minX, tl + minX), // Left
+            };
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/MansardRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/MansardRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a34ae0849ebce049b59d555cc134d2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -6,6 +6,10 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class RoofCollection
     {
+        public const uint DefaultGUID = 0x0cdcc049;
+
+        public uint PatternGUID { get; private set; }
+
         private List<IRoofType> _roofs;
         private _3DArrayView<float> _elevation;
         private int _baseFloor;
@@ -16,9 +20,17 @@ namespace OpenTS2.Scenes.Lot.Roof
             _elevation = elevation;
             _baseFloor = baseFloor;
 
+            uint patternGuid = 0;
+
             foreach (var entry in entries)
             {
+                patternGuid = entry.Pattern;
                 AddRoof(entry);
+            }
+
+            if (patternGuid == 0)
+            {
+                PatternGUID = DefaultGUID;
             }
         }
 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -93,6 +93,30 @@ namespace OpenTS2.Scenes.Lot.Roof
                     roof = new DiagonalShedHipRoof(entry, height);
                     break;
 
+                case RoofType.PagodaHip:
+                    roof = new HipRoof(entry, height, pagoda: true);
+                    break;
+
+                case RoofType.PagodaLongGable:
+                    roof = new GableRoof(entry, height, true, pagoda: true);
+                    break;
+
+                case RoofType.PagodaShedGable:
+                    roof = new ShedGableRoof(entry, height, pagoda: true);
+                    break;
+
+                case RoofType.DiagonalPagodaHip:
+                    roof = new DiagonalHipRoof(entry, height, pagoda: true);
+                    break;
+
+                case RoofType.DiagonalPagodaLongGable:
+                    roof = new DiagonalGableRoof(entry, height, true, pagoda: true);
+                    break;
+
+                case RoofType.DiagonalPagodaShedGable:
+                    roof = new DiagonalShedGableRoof(entry, height, pagoda: true);
+                    break;
+
                 default:
                     return;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -1,0 +1,103 @@
+using OpenTS2.Content.DBPF;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class RoofCollection
+    {
+        private List<IRoofType> _roofs;
+        private _3DArrayAsset<float> _elevation;
+        
+        public RoofCollection(RoofEntry[] entries, _3DArrayAsset<float> elevation)
+        {
+            _roofs = new List<IRoofType>();
+            _elevation = elevation;
+
+            foreach (var entry in entries)
+            {
+                AddRoof(entry);
+            }
+        }
+
+        private int CalculateElevationIndex(int x, int y)
+        {
+            return Mathf.Clamp(x, 0, _elevation.Width - 1) * _elevation.Height + Mathf.Clamp(y, 0, _elevation.Height - 1);
+        }
+
+        private float InterpHeight(float x, float y, int level)
+        {
+            float[] data = _elevation.Data[Mathf.Clamp(level, 0, _elevation.Depth - 1)];
+
+            float i0 = data[CalculateElevationIndex((int)x, (int)y)];
+            float i1 = data[CalculateElevationIndex((int)x + 1, (int)y)];
+            float j0 = data[CalculateElevationIndex((int)x, (int)y + 1)];
+            float j1 = data[CalculateElevationIndex((int)x + 1, (int)y + 1)];
+
+            float xi = x % 1;
+            float yi = y % 1;
+
+            return Mathf.Lerp(Mathf.Lerp(i0, i1, xi), Mathf.Lerp(j0, j1, xi), yi);
+        }
+
+        public void AddRoof(in RoofEntry entry)
+        {
+            IRoofType roof;
+            float height = InterpHeight(entry.XFrom, entry.YFrom, entry.LevelFrom);
+
+            switch (entry.Type)
+            {
+                case RoofType.ShedGabled:
+                    roof = new ShedGableRoof(entry, height);
+                    break;
+
+                case RoofType.ShedHipped:
+                    roof = new ShedHipRoof(entry, height);
+                    break;
+
+                case RoofType.ShortGable:
+                    roof = new GableRoof(entry, height, false);
+                    break;
+
+                case RoofType.LongGable:
+                    roof = new GableRoof(entry, height, true);
+                    break;
+
+                case RoofType.Hip:
+                    roof = new HipRoof(entry, height);
+                    break;
+
+                default:
+                    return;
+            }
+
+            _roofs.Add(roof);
+            // TODO: add intersections and tile removals for other roofs.
+        }
+
+        public float GetHeightAt(float x, float y)
+        {
+            // TODO: fast elimination based on roof rectangle/height?
+
+            foreach (var roof in _roofs)
+            {
+                float result = roof.GetHeightAt(x, y);
+
+                if (result != float.PositiveInfinity)
+                {
+                    return result;
+                }
+            }
+
+            return float.PositiveInfinity;
+        }
+
+        public void GenerateGeometry(RoofGeometryCollection geo)
+        {
+            foreach (var roof in _roofs)
+            {
+                roof.GenerateGeometry(geo);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -7,10 +7,10 @@ namespace OpenTS2.Scenes.Lot.Roof
     public class RoofCollection
     {
         private List<IRoofType> _roofs;
-        private _3DArrayAsset<float> _elevation;
+        private _3DArrayView<float> _elevation;
         private int _baseFloor;
         
-        public RoofCollection(RoofEntry[] entries, _3DArrayAsset<float> elevation, int baseFloor)
+        public RoofCollection(RoofEntry[] entries, _3DArrayView<float> elevation, int baseFloor)
         {
             _roofs = new List<IRoofType>();
             _elevation = elevation;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -69,6 +69,10 @@ namespace OpenTS2.Scenes.Lot.Roof
                     roof = new HipRoof(entry, height);
                     break;
 
+                case RoofType.Mansard:
+                    roof = new MansardRoof(entry, height);
+                    break;
+
                 default:
                     return;
             }
@@ -81,7 +85,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             _roofs.Add(roof);
         }
 
-        public float GetHeightAt(float x, float y, float fallback = float.PositiveInfinity)
+        public float GetHeightAt(float x, float y, float fallback = float.PositiveInfinity, float offset = 0)
         {
             // TODO: fast elimination based on roof rectangle/height?
 
@@ -97,7 +101,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                 }
             }
 
-            return bestHeight == float.NegativeInfinity ? fallback : bestHeight;
+            return bestHeight == float.NegativeInfinity ? fallback : bestHeight - offset;
         }
 
         public void GenerateGeometry(RoofGeometryCollection geo)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -75,27 +75,29 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             foreach (var existing in _roofs)
             {
-                //existing.Intersect(roof);
+                existing.Intersect(roof);
             }
 
             _roofs.Add(roof);
         }
 
-        public float GetHeightAt(float x, float y)
+        public float GetHeightAt(float x, float y, float fallback = float.PositiveInfinity)
         {
             // TODO: fast elimination based on roof rectangle/height?
+
+            float bestHeight = float.NegativeInfinity;
 
             foreach (var roof in _roofs)
             {
                 float result = roof.GetHeightAt(x, y);
 
-                if (result != float.PositiveInfinity)
+                if (result != float.PositiveInfinity && result > bestHeight)
                 {
-                    return result;
+                    bestHeight = result;
                 }
             }
 
-            return float.PositiveInfinity;
+            return bestHeight == float.NegativeInfinity ? fallback : bestHeight;
         }
 
         public void GenerateGeometry(RoofGeometryCollection geo)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -8,11 +8,13 @@ namespace OpenTS2.Scenes.Lot.Roof
     {
         private List<IRoofType> _roofs;
         private _3DArrayAsset<float> _elevation;
+        private int _baseFloor;
         
-        public RoofCollection(RoofEntry[] entries, _3DArrayAsset<float> elevation)
+        public RoofCollection(RoofEntry[] entries, _3DArrayAsset<float> elevation, int baseFloor)
         {
             _roofs = new List<IRoofType>();
             _elevation = elevation;
+            _baseFloor = baseFloor;
 
             foreach (var entry in entries)
             {
@@ -27,7 +29,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 
         private float InterpHeight(float x, float y, int level)
         {
-            float[] data = _elevation.Data[Mathf.Clamp(level, 0, _elevation.Depth - 1)];
+            float[] data = _elevation.Data[Mathf.Clamp(level - _baseFloor, 0, _elevation.Depth - 1)];
 
             float i0 = data[CalculateElevationIndex((int)x, (int)y)];
             float i1 = data[CalculateElevationIndex((int)x + 1, (int)y)];
@@ -71,8 +73,12 @@ namespace OpenTS2.Scenes.Lot.Roof
                     return;
             }
 
+            foreach (var existing in _roofs)
+            {
+                //existing.Intersect(roof);
+            }
+
             _roofs.Add(roof);
-            // TODO: add intersections and tile removals for other roofs.
         }
 
         public float GetHeightAt(float x, float y)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -73,6 +73,26 @@ namespace OpenTS2.Scenes.Lot.Roof
                     roof = new MansardRoof(entry, height);
                     break;
 
+                case RoofType.DiagonalLongGable:
+                    roof = new DiagonalGableRoof(entry, height, true);
+                    break;
+
+                case RoofType.DiagonalShortGable:
+                    roof = new DiagonalGableRoof(entry, height, false);
+                    break;
+
+                case RoofType.DiagonalHip:
+                    roof = new DiagonalHipRoof(entry, height);
+                    break;
+
+                case RoofType.DiagonalShedGable:
+                    roof = new DiagonalShedGableRoof(entry, height);
+                    break;
+
+                case RoofType.DiagonalShedHip:
+                    roof = new DiagonalShedHipRoof(entry, height);
+                    break;
+
                 default:
                     return;
             }
@@ -85,7 +105,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             _roofs.Add(roof);
         }
 
-        public float GetHeightAt(float x, float y, float fallback = float.PositiveInfinity, float offset = 0)
+        public float GetHeightAt(float x, float y, int floor, float fallback = float.PositiveInfinity, float offset = 0)
         {
             // TODO: fast elimination based on roof rectangle/height?
 
@@ -93,11 +113,14 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             foreach (var roof in _roofs)
             {
-                float result = roof.GetHeightAt(x, y);
-
-                if (result != float.PositiveInfinity && result > bestHeight)
+                if (roof.RoofEntry.LevelFrom == floor)
                 {
-                    bestHeight = result;
+                    float result = roof.GetHeightAt(x, y);
+
+                    if (result != float.PositiveInfinity && result > bestHeight)
+                    {
+                        bestHeight = result;
+                    }
                 }
             }
 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs
@@ -8,6 +8,11 @@ namespace OpenTS2.Scenes.Lot.Roof
     {
         public const uint DefaultGUID = 0x0cdcc049;
 
+        private const int RoofTopId = 0;
+        private const int RoofEdgesId = 1;
+        private const int RoofTrimId = 2;
+        private const int RoofUnderId = 3;
+
         public uint PatternGUID { get; private set; }
 
         private List<IRoofType> _roofs;
@@ -30,8 +35,10 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             if (patternGuid == 0)
             {
-                PatternGUID = DefaultGUID;
+                patternGuid = DefaultGUID;
             }
+
+            PatternGUID = patternGuid;
         }
 
         private int CalculateElevationIndex(int x, int y)
@@ -163,10 +170,26 @@ namespace OpenTS2.Scenes.Lot.Roof
             return bestHeight == float.NegativeInfinity ? fallback : bestHeight - offset;
         }
 
-        public void GenerateGeometry(RoofGeometryCollection geo)
+        public void GenerateGeometry(PatternMeshCollection patterns, int baseFloor)
         {
+            int floor = -1;
+            RoofGeometryCollection geo = default;
+
             foreach (var roof in _roofs)
             {
+                if (floor != roof.RoofEntry.LevelFrom)
+                {
+                    floor = roof.RoofEntry.LevelFrom;
+
+                    PatternMeshFloor meshFloor = patterns.GetFloor(floor - baseFloor);
+                    geo = new RoofGeometryCollection(
+                        meshFloor.Get(RoofTopId),
+                        meshFloor.Get(RoofEdgesId),
+                        meshFloor.Get(RoofTrimId),
+                        meshFloor.Get(RoofUnderId)
+                    );
+                }
+
                 roof.GenerateGeometry(geo);
             }
         }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec19752513bd36d4f86c9eaba83f07bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
@@ -523,6 +523,11 @@ namespace OpenTS2.Scenes.Lot.Roof
             return (x < _overhangSize && _lEnd != RoofEdgeEnd.FlatShort) || (x >= _tileWidth - _overhangSize && _rEnd != RoofEdgeEnd.FlatShort) || y >= _tileHeight - _overhangSize || y < _topOverhangSize;
         }
 
+        private bool IsOverhangX(int x, int y)
+        {
+            return (x < _overhangSize && _lEnd != RoofEdgeEnd.FlatShort) || (x >= _tileWidth - _overhangSize && _rEnd != RoofEdgeEnd.FlatShort);
+        }
+
         public bool Intersect(RoofEdge other)
         {
             // Can only run this if tiles line up.
@@ -620,7 +625,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                                     if (thisHigher)
                                     {
-                                        if (!IsOverhang(x, y) || _height == other._height)
+                                        if (!IsOverhang(x, y) || (_height == other._height && other.IsOverhangX(xO, yO)))
                                         {
                                             // Only real roof can remove lower tiles if they're on a different level.
                                             other.CutUsingTile(tile, xO, yO, 0);
@@ -628,7 +633,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                                     }
                                     else
                                     {
-                                        if (!other.IsOverhang(xO, yO) || _height == other._height)
+                                        if (!other.IsOverhang(xO, yO) || (_height == other._height && IsOverhangX(x, y)))
                                         {
                                             CutUsingTile(oTile, x, y, 0);
                                         }
@@ -692,14 +697,20 @@ namespace OpenTS2.Scenes.Lot.Roof
                                     {
                                         // The fun one.
 
-                                        // Cut the top left of the left edge into the right edge.
-                                        RoofCut cutFromL = (tile.Cuts() & RoofCut.TopLeft) | RoofCut.BottomRight;
-                                        oTile.Cut(cutFromL, 1);
+                                        bool lOverhang = left.IsOverhang(x, y);
+                                        bool rOverhang = right.IsOverhang(xO, yO);
 
-                                        // Cut the top right of the right edge into the left edge.
+                                        if (lOverhang == rOverhang)
+                                        {
+                                            // Cut the top left of the left edge into the right edge.
+                                            RoofCut cutFromL = (tile.Cuts() & RoofCut.TopLeft) | RoofCut.BottomRight;
+                                            oTile.Cut(cutFromL, 1);
 
-                                        RoofCut cutFromR = (oTile.Cuts() & RoofCut.TopRight) | RoofCut.BottomLeft;
-                                        tile.Cut(cutFromR, 3);
+                                            // Cut the top right of the right edge into the left edge.
+
+                                            RoofCut cutFromR = (oTile.Cuts() & RoofCut.TopRight) | RoofCut.BottomLeft;
+                                            tile.Cut(cutFromR, 3);
+                                        }
 
                                         // Only add the intersection graphics to the left face if the right isn't fully cut out.
                                         if ((oTile.Cuts() & RoofCut.TopRight) != RoofCut.TopRight)
@@ -787,7 +798,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                                 if (tileHeight < tileHeightOther)
                                 {
-                                    if (!other.IsOverhang(xO, yO) || _height == other._height)
+                                    if (!other.IsOverhang(xO, yO) || (_height == other._height && IsOverhangX(x, y)))
                                     {
                                         CutUsingTile(oTile, x, y, dirDiff);
                                     }
@@ -809,7 +820,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                                 }
                                 else
                                 {
-                                    if (!IsOverhang(x, y) || _height == other._height)
+                                    if (!IsOverhang(x, y) || (_height == other._height && other.IsOverhangX(xO, yO)))
                                     {
                                         other.CutUsingTile(tile, xO, yO, dirDiff);
                                     }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.Xml;
 using UnityEngine;
+using UnityEngine.Tilemaps;
 
 namespace OpenTS2.Scenes.Lot.Roof
 {
@@ -12,8 +15,8 @@ namespace OpenTS2.Scenes.Lot.Roof
     {
         private const float ThicknessTop = 0.075f;
         private const float ThicknessInner = 0.15f;
-        private const float ThicknessTotal = 0.075f;
-        private const float Overflow = 0.5f;
+        private const float ThicknessTotal = ThicknessTop + ThicknessInner;
+        private const float TileSize = 0.5f;
 
         private const float Bias = 0.0001f;
         private List<Vector2> _intersectionLine;
@@ -37,8 +40,17 @@ namespace OpenTS2.Scenes.Lot.Roof
         private bool _lFlat;
         private bool _rFlat;
 
+        // Roof Tiles
+        private RoofTile[] _tiles;
+        private int _tileWidth;
+        private int _tileHeight;
+
+        private float _tileScale;
+
         private Vector3[] _vertices;
+        private Vector3[] _edgeVertices;
         private Vector2[] _uvs;
+        private Vector2[] _edgeUVs;
 
         public RoofEdge(float height, float slope, Vector2 bl, Vector2 br, Vector2 tr, Vector2 tl, bool lFlat = false, bool rFlat = false)
         {
@@ -47,8 +59,16 @@ namespace OpenTS2.Scenes.Lot.Roof
             _height = height;
             _slope = slope;
 
+            _bl = bl;
+            _tl = tl; // Used
+            _br = br;
+            _tr = tr;
+
             _yNormal = tl - bl;
             _xNormal = br - bl;
+
+            float xDist = _xNormal.magnitude;
+            float yDist = _yNormal.magnitude;
 
             _yNormal.Normalize();
             _xNormal.Normalize();
@@ -62,13 +82,231 @@ namespace OpenTS2.Scenes.Lot.Roof
             _rFlat = rFlat;
 
             _vertices = new Vector3[4];
+            _edgeVertices = new Vector3[4];
             _uvs = new Vector2[4];
+            _edgeUVs = new Vector2[]
+            {
+                new Vector2(0, 1),
+                new Vector2(1, 1),
+                new Vector2(1, 0),
+                new Vector2(0, 0),
+            };
+
+            _tileWidth = Mathf.RoundToInt(xDist / TileSize) + 2;
+            _tileHeight = Mathf.RoundToInt(yDist / TileSize) + 1;
+            _tiles = new RoofTile[_tileWidth * _tileHeight];
+
+            InitTiles();
+        }
+
+        private void InitTiles()
+        {
+            int mid = 0;
+
+            if (!_rFlat && !_lFlat)
+            {
+                mid = _tileWidth / 2;
+            }
+            else if (!_lFlat)
+            {
+                mid = _tileWidth;
+            }
+
+            int i = 0;
+            for (int y = 0; y < _tileHeight; y++)
+            {
+                for (int x = 0; x < _tileWidth; x++, i++)
+                {
+                    ref RoofTile tile = ref _tiles[i];
+
+                    int side = x + y;
+                    int oside = ((_tileWidth - 1) - x) + y;
+
+                    if (!_lFlat && x < mid)
+                    {
+                        if (side <= _tileHeight)
+                        {
+                            if (side == _tileHeight)
+                            {
+                                tile = new RoofTile(y != 0 ? RoofTileBase.SmallLeftEdge : RoofTileBase.LeftToTop);
+                            }
+                            else if (side == _tileHeight - 1)
+                            {
+                                tile = new RoofTile(RoofTileBase.LeftEdge);
+                            }
+                            else
+                            {
+                                tile.Delete();
+                            }
+
+                            continue;
+                        }
+                    }
+
+                    if (!_rFlat && x >= mid)
+                    {
+                        if (oside <= _tileHeight)
+                        {
+                            if (oside == _tileHeight)
+                            {
+                                tile = new RoofTile(y != 0 ? RoofTileBase.SmallRightEdge : RoofTileBase.TopToRight);
+                            }
+                            else if (oside == _tileHeight - 1)
+                            {
+                                tile = new RoofTile(RoofTileBase.RightEdge);
+                            }
+                            else
+                            {
+                                tile.Delete();
+                            }
+
+                            continue;
+                        }
+                    }
+
+                    tile = new RoofTile(y == 0 ? RoofTileBase.Top : RoofTileBase.Normal);
+                }
+            }
+        }
+
+        private void DrawTrim(LotFloorPatternComponent trimComp, LotFloorPatternComponent edgeComp, Vector3 from, Vector3 to)
+        {
+            _edgeVertices[0] = from;
+            _edgeVertices[1] = to;
+            _edgeVertices[2] = to + new Vector3(0, -ThicknessTop, 0);
+            _edgeVertices[3] = from + new Vector3(0, -ThicknessTop, 0);
+
+            int trimVertex = trimComp.GetVertexIndex();
+
+            trimComp.AddVertices(_edgeVertices, _edgeUVs);
+            trimComp.AddTriangle(trimVertex, 0, 1, 2);
+            trimComp.AddTriangle(trimVertex, 2, 3, 0);
+
+            _edgeVertices[0] = _edgeVertices[3];
+            _edgeVertices[1] = _edgeVertices[2];
+            _edgeVertices[2] = _edgeVertices[2] + new Vector3(0, -ThicknessInner, 0);
+            _edgeVertices[3] = _edgeVertices[3] + new Vector3(0, -ThicknessInner, 0);
+
+            int edgeVertex = edgeComp.GetVertexIndex();
+
+            edgeComp.AddVertices(_edgeVertices, _edgeUVs);
+            edgeComp.AddTriangle(edgeVertex, 0, 1, 2);
+            edgeComp.AddTriangle(edgeVertex, 2, 3, 0);
+        }
+
+        private int AddUndersideVerts(LotFloorPatternComponent underComp)
+        {
+            var off = new Vector3(0, -ThicknessTotal, 0);
+            int index = underComp.GetVertexIndex();
+
+            _edgeVertices[0] = _vertices[0] + off;
+            _edgeVertices[1] = _vertices[1] + off;
+            _edgeVertices[2] = _vertices[2] + off;
+            _edgeVertices[3] = _vertices[3] + off;
+
+            underComp.AddVertices(_edgeVertices, _edgeUVs);
+
+            return index;
         }
 
         public void GenerateGeometry(RoofGeometryCollection geo)
         {
+            var trimComp = geo.RoofTrim.Component;
+            var edgeComp = geo.RoofEdges.Component;
             var topComp = geo.RoofTop.Component;
-        }
+            var underComp = geo.RoofUnder.Component;
+
+            Vector3 basePos = new Vector3(_tl.x, _height + (_tileHeight - 1) * _slope + ThicknessTop, _tl.y);
+
+            Vector3 xTile = new Vector3(_xNormal.x * TileSize, 0, _xNormal.y * TileSize);
+            Vector3 yTile = new Vector3(_yNormal.x * -TileSize, -_slope, _yNormal.y * -TileSize);
+
+            basePos -= xTile;
+
+            int i = 0;
+            for (int y = 0; y < _tileHeight; y++)
+            {
+                for (int x = 0; x < _tileWidth; x++, i++)
+                {
+                    ref RoofTile tile = ref _tiles[i];
+
+                    AtlasIndex graphic = tile.GetAtlasIndex();
+
+                    if (graphic.Index == -1)
+                    {
+                        continue;
+                    }
+
+                    _vertices[0] = basePos + x * xTile + y * yTile; // Top Left
+                    _vertices[1] = _vertices[0] + xTile; // Top Right
+                    _vertices[2] = _vertices[1] + yTile; // Bottom Right
+                    _vertices[3] = _vertices[0] + yTile; // Bottom Left
+
+                    Vector2 baseUV = new Vector2((graphic.Index % 5) * 0.2f, 1 - (graphic.Index / 5) * 0.2f);
+
+                    _uvs[0] = baseUV + new Vector2(0, -0.2f);
+                    _uvs[1] = baseUV + new Vector2(0.2f, -0.2f);
+                    _uvs[2] = baseUV + new Vector2(0.2f, 0);
+                    _uvs[3] = baseUV;
+
+                    if (graphic.Flip)
+                    {
+                        (_uvs[0], _uvs[1], _uvs[2], _uvs[3]) = (_uvs[1], _uvs[0], _uvs[3], _uvs[2]);
+                    }
+
+                    int baseVertex = topComp.GetVertexIndex();
+
+                    topComp.AddVertices(_vertices, _uvs);
+
+                    int cut = tile.CutDir();
+
+                    int underVertex = AddUndersideVerts(underComp);
+
+                    if (cut == 0)
+                    {
+                        topComp.AddTriangle(baseVertex, 0, 1, 2);
+                        topComp.AddTriangle(baseVertex, 2, 3, 0);
+
+                        underComp.AddTriangle(underVertex, 1, 0, 2);
+                        underComp.AddTriangle(underVertex, 3, 2, 0);
+                    }
+                    else if (cut == -1)
+                    {
+                        topComp.AddTriangle(baseVertex, 1, 2, 3);
+                        underComp.AddTriangle(underVertex, 2, 1, 3);
+                    }
+                    else if (cut == 1)
+                    {
+                        topComp.AddTriangle(baseVertex, 0, 2, 3);
+                        underComp.AddTriangle(underVertex, 2, 0, 3);
+                    }
+
+                    if (y == 0 && cut == 0)
+                    {
+                        // Draw top edge
+                        DrawTrim(trimComp, edgeComp, _vertices[0], _vertices[1]);
+                    }
+
+                    if (y == _tileHeight - 1)
+                    {
+                        // Draw bottom edge
+                        DrawTrim(trimComp, edgeComp, _vertices[3], _vertices[2]);
+                    }
+
+                    if (_lFlat && x == 0)
+                    {
+                        // Draw left edge
+                        DrawTrim(trimComp, edgeComp, _vertices[0], _vertices[3]);
+                    }
+
+                    if (_rFlat && x == _tileWidth - 1)
+                    {
+                        // Draw right edge
+                        DrawTrim(trimComp, edgeComp, _vertices[2], _vertices[1]);
+                    }
+                }
+            }
+         }
 
         public float GetHeightAt(float x, float y)
         {
@@ -91,6 +329,254 @@ namespace OpenTS2.Scenes.Lot.Roof
             }
 
             return yDist * (_slope * 2) + _height;
+        }
+
+        public bool Intersect(RoofEdge other)
+        {
+            // Can only run this if tiles line up.
+
+            float heightOffset = _height / _slope - other._height / other._slope;
+
+            if (_slope != other._slope || Math.Abs(heightOffset - Mathf.Round(heightOffset)) > Bias)
+            {
+                return false;
+            }
+
+            float dir = Vector2.Angle(_xNormal, other._xNormal);
+
+            if (Vector2.Dot(_xNormal, other._yNormal) < 0)
+            {
+                dir *= -1;
+            }
+
+            float notches = dir / 90;
+
+            if (Math.Abs(Math.Round(notches) - notches) > Bias)
+            {
+                // Not at a 90 degree angle.
+                return false;
+            }
+
+            int dirDiff = ((int)Math.Round(notches) + 4) % 4;
+
+            Vector3 basePos = new Vector3(_tl.x, _height + (_tileHeight - 1) * _slope, _tl.y);
+            Vector3 otherBasePos = new Vector3(other._tl.x, other._height + (other._tileHeight - 1) * _slope, other._tl.y);
+
+            Vector3 xTile = new Vector3(_xNormal.x * TileSize, 0, _xNormal.y * TileSize);
+            Vector3 yTile = new Vector3(_yNormal.x * -TileSize, -_slope, _yNormal.y * -TileSize);
+
+            switch (dirDiff)
+            {
+                case 0:
+                    {
+                        // Roofs are parallel. If one roof is entirely over the other, remove the lower tiles.
+                        // If the two roofs occupy the same space, select tiles that best represent both roofs and delete the tile on the other.
+
+                        float xTileOffset = Vector2.Dot(_xNormal, other._tl - _tl) / TileSize;
+                        float yTileOffset = Vector2.Dot(_yNormal, other._tl - _tl) / TileSize;
+
+                        int xTO = Mathf.RoundToInt(xTileOffset);
+                        int yTO = Mathf.RoundToInt(yTileOffset);
+
+                        //if (xTO > _tileWidth)
+
+                        int heightOffsetTiles = yTO + (_tileHeight - other._tileHeight);  // yTO difference at base
+
+                        // How much above the other edge are we?
+                        float heightDiff = (_height - other._height) + heightOffsetTiles * _slope;
+
+                        int xFrom = Math.Max(0, xTO);
+                        int xTo = Math.Min(_tileWidth - 1, xTO + other._tileWidth);
+                        int yFrom = Math.Max(0, -yTO);
+                        int yTo = Math.Min(_tileHeight - 1, other._tileHeight - yTO);
+                        int xFromOther = Math.Max(0, -xTO);
+                        int yFromOther = Math.Max(0, yTO);
+
+                        if (Math.Abs(heightDiff) < Bias)
+                        {
+                            // Roofs are roughly the same height.
+                            // Prefer tiles from one roof with a higher priority.
+
+                            for (int y = yFrom, yO = yFromOther; y <= yTo; y++, yO++)
+                            {
+                                for (int x = xFrom, xO = xFromOther; x <= xTo; x++, xO++)
+                                {
+                                    ref RoofTile tile = ref _tiles[y * _tileWidth + x];
+                                    ref RoofTile oTile = ref other._tiles[yO * other._tileWidth + xO];
+
+                                    int prio1 = tile.OverlapPriority();
+                                    int prio2 = tile.OverlapPriority();
+
+                                    if (prio1 > prio2)
+                                    {
+                                        oTile.Delete();
+                                    }
+                                    else
+                                    {
+                                        tile.Delete();
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            bool thisHigher = heightDiff > 0;
+                            
+                            // Remove lower tiles
+                            for (int y = yFrom, yO = yFromOther; y <= yTo; y++, yO++)
+                            {
+                                for (int x = xFrom, xO = xFromOther; x <= xTo; x++, xO++)
+                                {
+                                    if (x == 0 || x == _tileWidth - 1 || y == _tileHeight - 1 ||
+                                        xO == 0 || xO == other._tileWidth - 1 || yO == other._tileWidth - 1)
+                                    {
+                                        // Don't remove overhangs due to vertical overlap.
+                                        // Only remove them if their donor tiles disappear.
+                                        continue;
+                                    }
+
+                                    ref RoofTile tile = ref _tiles[y * _tileWidth + x];
+                                    ref RoofTile oTile = ref other._tiles[yO * other._tileWidth + xO];
+
+                                    if (thisHigher)
+                                    {
+                                        oTile.Delete();
+
+                                        // Does this remove an overhang?
+
+                                        if (xO == 1)
+                                        {
+                                            // Removes left overhang
+                                            other._tiles[yO * other._tileWidth].Delete();
+
+                                            if (yO == other._tileHeight - 2)
+                                            {
+                                                // ... and bottom corner
+                                                other._tiles[(yO + 1) * other._tileWidth].Delete();
+                                            }
+                                        }
+                                        else if (xO == other._tileWidth - 2)
+                                        {
+                                            // Removes right overhang
+                                            other._tiles[yO * other._tileWidth + xO + 1].Delete();
+
+                                            if (yO == other._tileHeight - 2)
+                                            {
+                                                // ... and bottom corner
+                                                other._tiles[(yO + 1) * other._tileWidth + xO + 1].Delete();
+                                            }
+                                        }
+                                        else if (yO == other._tileHeight - 2)
+                                        {
+                                            other._tiles[(yO + 1) * other._tileWidth].Delete();
+                                        }
+                                    }
+                                    else
+                                    {
+                                        tile.Delete();
+
+                                        // Does this remove an overhang?
+
+                                        if (x == 1)
+                                        {
+                                            // Removes left overhang
+                                            _tiles[y * _tileWidth].Delete();
+
+                                            if (y == _tileHeight - 2)
+                                            {
+                                                // ... and bottom corner
+                                                _tiles[(y + 1) * _tileWidth].Delete();
+                                            }
+                                        }
+                                        else if (x == _tileWidth - 2)
+                                        {
+                                            // Removes right overhang
+                                            _tiles[yO * _tileWidth + x + 1].Delete();
+
+                                            if (yO == _tileHeight - 2)
+                                            {
+                                                // ... and bottom corner
+                                                _tiles[(y + 1) * _tileWidth + x + 1].Delete();
+                                            }
+                                        }
+                                        else if (y == _tileHeight - 2)
+                                        {
+                                            _tiles[(y + 1) * _tileWidth].Delete();
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        return true;
+                        //break;
+                    }
+                case 1:
+                    {
+                        // Other wall is 90 degrees from this one.
+                        // This wall sees a diagonal intersection in form /
+                        // The other sees \
+                        break;
+                    }
+                case 2:
+                    {
+                        // Roofs are opposite. Try find where the roofs intersect. Remove whichever one is lower, and on the intersection line add a cut.
+                        break;
+                    }
+                case 3:
+                    {
+                        // Other wall is -90 degrees from this one.
+                        // This wall sees a diagonal intersection in form \
+                        // The other sees /
+                        break;
+                    }
+
+            }
+
+            return false;
+        }
+
+        public void RemoveTilesUnder(IRoofType other)
+        {
+            // This method runs when a roof cannot be intersected, such as roofs with different slope or unusual shape.
+            // A tile can only be removed if all four of its corners are under another roof.
+            Vector3 basePos = new Vector3(_tl.x, _height + (_tileHeight - 1) * _slope, _tl.y);
+
+            Vector3 xTile = new Vector3(_xNormal.x * TileSize, 0, _xNormal.y * TileSize);
+            Vector3 yTile = new Vector3(_yNormal.x * -TileSize, -_slope, _yNormal.y * -TileSize);
+
+            basePos -= xTile;
+
+            int i = 0;
+            for (int y = 0; y < _tileHeight; y++)
+            {
+                for (int x = 0; x < _tileWidth; x++, i++)
+                {
+                    Vector3 tl = basePos + x * xTile + y * yTile; // Top Left
+                    Vector3 tr = tl + xTile; // Top Right
+                    Vector3 br = tr + yTile; // Bottom Right
+                    Vector3 bl = tl + yTile; // Bottom Left
+
+                    float tlH = other.GetHeightAt(tl.x, tl.z);
+                    if (tlH != float.PositiveInfinity && tl.y + Bias < tlH)
+                    {
+                        float trH = other.GetHeightAt(tr.x, tr.z);
+                        if (trH != float.PositiveInfinity && tr.y + Bias < trH)
+                        {
+                            float brH = other.GetHeightAt(br.x, br.z);
+                            if (brH != float.PositiveInfinity && br.y + Bias < brH)
+                            {
+                                float blH = other.GetHeightAt(bl.x, bl.z);
+                                if (blH != float.PositiveInfinity && bl.y + Bias < blH)
+                                {
+                                    // Remove this tile.
+                                    _tiles[i].Delete();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    /// <summary>
+    /// A roof edge describes one side of a roof.
+    /// This keeps track of an "intersection line" which represents the
+    /// highest intersecting line of any roof across the surface.
+    /// </summary>
+    public class RoofEdge
+    {
+        private const float ThicknessTop = 0.075f;
+        private const float ThicknessInner = 0.15f;
+        private const float ThicknessTotal = 0.075f;
+        private const float Overflow = 0.5f;
+
+        private const float Bias = 0.0001f;
+        private List<Vector2> _intersectionLine;
+
+        private float _height;
+        private float _slope;
+
+        private Vector2 _bl;
+        private Vector2 _br;
+        private Vector2 _tr;
+        private Vector2 _tl;
+
+        private Vector2 _yNormal;
+        private Vector2 _xNormal;
+
+        private float _bPc;
+        private float _rPc;
+        private float _tPc;
+        private float _lPc;
+
+        private bool _lFlat;
+        private bool _rFlat;
+
+        private Vector3[] _vertices;
+        private Vector2[] _uvs;
+
+        public RoofEdge(float height, float slope, Vector2 bl, Vector2 br, Vector2 tr, Vector2 tl, bool lFlat = false, bool rFlat = false)
+        {
+            _intersectionLine = new List<Vector2>();
+
+            _height = height;
+            _slope = slope;
+
+            _yNormal = tl - bl;
+            _xNormal = br - bl;
+
+            _yNormal.Normalize();
+            _xNormal.Normalize();
+
+            _bPc = Vector2.Dot(_yNormal, bl);
+            _rPc = Vector2.Dot(_xNormal, br);
+            _tPc = Vector2.Dot(_yNormal, tr);
+            _lPc = Vector2.Dot(_xNormal, tl);
+
+            _lFlat = lFlat;
+            _rFlat = rFlat;
+
+            _vertices = new Vector3[4];
+            _uvs = new Vector2[4];
+        }
+
+        public void GenerateGeometry(RoofGeometryCollection geo)
+        {
+            var topComp = geo.RoofTop.Component;
+        }
+
+        public float GetHeightAt(float x, float y)
+        {
+            Vector2 pos = new Vector2(x, y);
+
+            float dotX = Vector2.Dot(pos, _xNormal);
+            float dotY = Vector2.Dot(pos, _yNormal);
+
+            if (dotX < _lPc || dotX > _rPc || dotY < _bPc || dotY > _tPc)
+            {
+                return float.PositiveInfinity;
+            }
+
+            float yDist = dotY - _bPc;
+
+            if ((!_lFlat && dotX - _lPc < yDist) || (!_rFlat && _rPc - dotX < yDist))
+            {
+                // If the edges are not flat, also cut off top 45 degrees from left and right.
+                return float.PositiveInfinity;
+            }
+
+            return yDist * (_slope * 2) + _height;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
@@ -276,7 +276,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             }
         }
 
-        private void DrawTrim(LotFloorPatternComponent trimComp, LotFloorPatternComponent edgeComp, Vector3 from, Vector3 to)
+        private void DrawTrim(LotArchitectureMeshComponent trimComp, LotArchitectureMeshComponent edgeComp, Vector3 from, Vector3 to)
         {
             _edgeVertices[0] = from;
             _edgeVertices[1] = to;
@@ -301,7 +301,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             edgeComp.AddTriangle(edgeVertex, 2, 3, 0);
         }
 
-        private int AddUndersideVerts(LotFloorPatternComponent underComp)
+        private int AddUndersideVerts(LotArchitectureMeshComponent underComp)
         {
             var off = new Vector3(0, -ThicknessTotal, 0);
             int index = underComp.GetVertexIndex();

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Xml;
 using UnityEngine;
 using UnityEngine.Tilemaps;
+using UnityEngine.WSA;
 
 namespace OpenTS2.Scenes.Lot.Roof
 {
@@ -17,6 +18,9 @@ namespace OpenTS2.Scenes.Lot.Roof
         private const float ThicknessInner = 0.15f;
         private const float ThicknessTotal = ThicknessTop + ThicknessInner;
         private const float TileSize = 0.5f;
+
+        private const float AtlasUVYOff = 2f / 512f;
+        private const float AtlasUVSize = 102f / 512f;
 
         private const float Bias = 0.0001f;
         private List<Vector2> _intersectionLine;
@@ -48,9 +52,13 @@ namespace OpenTS2.Scenes.Lot.Roof
         private float _tileScale;
 
         private Vector3[] _vertices;
-        private Vector3[] _edgeVertices;
         private Vector2[] _uvs;
+
+        private Vector3[] _edgeVertices;
         private Vector2[] _edgeUVs;
+
+        private Vector3[] _underVertices;
+        private Vector2[] _underUVs;
 
         public RoofEdge(float height, float slope, Vector2 bl, Vector2 br, Vector2 tr, Vector2 tl, bool lFlat = false, bool rFlat = false)
         {
@@ -81,15 +89,26 @@ namespace OpenTS2.Scenes.Lot.Roof
             _lFlat = lFlat;
             _rFlat = rFlat;
 
-            _vertices = new Vector3[4];
+            _vertices = new Vector3[5];
+            _uvs = new Vector2[5];
+
             _edgeVertices = new Vector3[4];
-            _uvs = new Vector2[4];
             _edgeUVs = new Vector2[]
             {
                 new Vector2(0, 1),
                 new Vector2(1, 1),
                 new Vector2(1, 0),
                 new Vector2(0, 0),
+            };
+
+            _underVertices = new Vector3[5];
+            _underUVs = new Vector2[]
+            {
+                new Vector2(0, 1),
+                new Vector2(1, 1),
+                new Vector2(1, 0),
+                new Vector2(0, 0),
+                new Vector2(0.5f, 0.5f),
             };
 
             _tileWidth = Mathf.RoundToInt(xDist / TileSize) + 2;
@@ -199,12 +218,13 @@ namespace OpenTS2.Scenes.Lot.Roof
             var off = new Vector3(0, -ThicknessTotal, 0);
             int index = underComp.GetVertexIndex();
 
-            _edgeVertices[0] = _vertices[0] + off;
-            _edgeVertices[1] = _vertices[1] + off;
-            _edgeVertices[2] = _vertices[2] + off;
-            _edgeVertices[3] = _vertices[3] + off;
+            _underVertices[0] = _vertices[0] + off;
+            _underVertices[1] = _vertices[1] + off;
+            _underVertices[2] = _vertices[2] + off;
+            _underVertices[3] = _vertices[3] + off;
+            _underVertices[4] = _vertices[4] + off;
 
-            underComp.AddVertices(_edgeVertices, _edgeUVs);
+            underComp.AddVertices(_underVertices, _underUVs);
 
             return index;
         }
@@ -241,13 +261,15 @@ namespace OpenTS2.Scenes.Lot.Roof
                     _vertices[1] = _vertices[0] + xTile; // Top Right
                     _vertices[2] = _vertices[1] + yTile; // Bottom Right
                     _vertices[3] = _vertices[0] + yTile; // Bottom Left
+                    _vertices[4] = (_vertices[0] + _vertices[1] + _vertices[2] + _vertices[3]) / 4; // Center
 
-                    Vector2 baseUV = new Vector2((graphic.Index % 5) * 0.2f, 1 - (graphic.Index / 5) * 0.2f);
+                    Vector2 baseUV = new Vector2((graphic.Index % 5) * AtlasUVSize, 1 - ((graphic.Index / 5) * AtlasUVSize + AtlasUVYOff));
 
-                    _uvs[0] = baseUV + new Vector2(0, -0.2f);
-                    _uvs[1] = baseUV + new Vector2(0.2f, -0.2f);
-                    _uvs[2] = baseUV + new Vector2(0.2f, 0);
+                    _uvs[0] = baseUV + new Vector2(0, -AtlasUVSize);
+                    _uvs[1] = baseUV + new Vector2(AtlasUVSize, -AtlasUVSize);
+                    _uvs[2] = baseUV + new Vector2(AtlasUVSize, 0);
                     _uvs[3] = baseUV;
+                    _uvs[4] = baseUV + new Vector2(AtlasUVSize / 2, -AtlasUVSize / 2);
 
                     if (graphic.Flip)
                     {
@@ -258,7 +280,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                     topComp.AddVertices(_vertices, _uvs);
 
-                    int cut = tile.CutDir();
+                    RoofCut cut = tile.Cuts();
 
                     int underVertex = AddUndersideVerts(underComp);
 
@@ -270,36 +292,53 @@ namespace OpenTS2.Scenes.Lot.Roof
                         underComp.AddTriangle(underVertex, 1, 0, 2);
                         underComp.AddTriangle(underVertex, 3, 2, 0);
                     }
-                    else if (cut == -1)
+                    else
                     {
-                        topComp.AddTriangle(baseVertex, 1, 2, 3);
-                        underComp.AddTriangle(underVertex, 2, 1, 3);
-                    }
-                    else if (cut == 1)
-                    {
-                        topComp.AddTriangle(baseVertex, 0, 2, 3);
-                        underComp.AddTriangle(underVertex, 2, 0, 3);
+                        // 4 triangle cut.
+                        if ((cut & RoofCut.Top) == 0)
+                        {
+                            topComp.AddTriangle(baseVertex, 0, 1, 4);
+                            underComp.AddTriangle(underVertex, 1, 0, 4);
+                        }
+
+                        if ((cut & RoofCut.Right) == 0)
+                        {
+                            topComp.AddTriangle(baseVertex, 1, 2, 4);
+                            underComp.AddTriangle(underVertex, 2, 1, 4);
+                        }
+
+                        if ((cut & RoofCut.Bottom) == 0)
+                        {
+                            topComp.AddTriangle(baseVertex, 2, 3, 4);
+                            underComp.AddTriangle(underVertex, 3, 2, 4);
+                        }
+
+                        if ((cut & RoofCut.Left) == 0)
+                        {
+                            topComp.AddTriangle(baseVertex, 3, 0, 4);
+                            underComp.AddTriangle(underVertex, 0, 3, 4);
+                        }
                     }
 
-                    if (y == 0 && cut == 0)
+                    if (y == 0 && (cut & RoofCut.Top) == 0)
                     {
                         // Draw top edge
-                        DrawTrim(trimComp, edgeComp, _vertices[0], _vertices[1]);
+                        DrawTrim(trimComp, edgeComp, _vertices[1], _vertices[0]);
                     }
 
-                    if (y == _tileHeight - 1)
+                    if (y == _tileHeight - 1 && (cut & RoofCut.Bottom) == 0)
                     {
                         // Draw bottom edge
                         DrawTrim(trimComp, edgeComp, _vertices[3], _vertices[2]);
                     }
 
-                    if (_lFlat && x == 0)
+                    if (_lFlat && x == 0 && (cut & RoofCut.Left) == 0)
                     {
                         // Draw left edge
                         DrawTrim(trimComp, edgeComp, _vertices[0], _vertices[3]);
                     }
 
-                    if (_rFlat && x == _tileWidth - 1)
+                    if (_rFlat && x == _tileWidth - 1 && (cut & RoofCut.Right) == 0)
                     {
                         // Draw right edge
                         DrawTrim(trimComp, edgeComp, _vertices[2], _vertices[1]);
@@ -331,6 +370,51 @@ namespace OpenTS2.Scenes.Lot.Roof
             return yDist * (_slope * 2) + _height;
         }
 
+        private void CutUsingTile(in RoofTile oTile, int x, int y, int dir)
+        {
+            ref RoofTile tile = ref _tiles[y * _tileWidth + x];
+
+            RoofCut cut = tile.Cut(oTile, dir);
+
+            // Does this remove an overhang?
+
+            if (x == 1 && (cut & RoofCut.Left) != 0)
+            {
+                // Removes left overhang
+                _tiles[y * _tileWidth].Delete();
+
+                // TODO: remove based on cut
+
+                if (y == _tileHeight - 2 && (cut & RoofCut.Bottom) != 0)
+                {
+                    // ... and bottom corner
+                    _tiles[(y + 1) * _tileWidth + x].Delete();
+                    _tiles[(y + 1) * _tileWidth].Delete();
+                }
+            }
+            else if (x == _tileWidth - 2 && (cut & RoofCut.Right) != 0)
+            {
+                // Removes right overhang
+                _tiles[y * _tileWidth + x + 1].Delete();
+
+                if (y == _tileHeight - 2 && (cut & RoofCut.Bottom) != 0)
+                {
+                    // ... and bottom corner
+                    _tiles[(y + 1) * _tileWidth + x].Delete();
+                    _tiles[(y + 1) * _tileWidth + x + 1].Delete();
+                }
+            }
+            else if (y == _tileHeight - 2 && (cut & RoofCut.Bottom) != 0)
+            {
+                _tiles[(y + 1) * _tileWidth + x].Delete();
+            }
+        }
+
+        private bool IsOverhang(int x, int y)
+        {
+            return x == 0 || x == _tileWidth - 1 || y == _tileHeight - 1;
+        }
+
         public bool Intersect(RoofEdge other)
         {
             // Can only run this if tiles line up.
@@ -359,26 +443,18 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             int dirDiff = ((int)Math.Round(notches) + 4) % 4;
 
-            Vector3 basePos = new Vector3(_tl.x, _height + (_tileHeight - 1) * _slope, _tl.y);
-            Vector3 otherBasePos = new Vector3(other._tl.x, other._height + (other._tileHeight - 1) * _slope, other._tl.y);
+            float xTileOffset = Vector2.Dot(_xNormal, other._tl - _tl) / TileSize;
+            float yTileOffset = Vector2.Dot(_yNormal, other._tl - _tl) / TileSize;
 
-            Vector3 xTile = new Vector3(_xNormal.x * TileSize, 0, _xNormal.y * TileSize);
-            Vector3 yTile = new Vector3(_yNormal.x * -TileSize, -_slope, _yNormal.y * -TileSize);
+            int xTO = Mathf.RoundToInt(xTileOffset);
+            int yTO = Mathf.RoundToInt(yTileOffset);
 
             switch (dirDiff)
             {
                 case 0:
                     {
                         // Roofs are parallel. If one roof is entirely over the other, remove the lower tiles.
-                        // If the two roofs occupy the same space, select tiles that best represent both roofs and delete the tile on the other.
-
-                        float xTileOffset = Vector2.Dot(_xNormal, other._tl - _tl) / TileSize;
-                        float yTileOffset = Vector2.Dot(_yNormal, other._tl - _tl) / TileSize;
-
-                        int xTO = Mathf.RoundToInt(xTileOffset);
-                        int yTO = Mathf.RoundToInt(yTileOffset);
-
-                        //if (xTO > _tileWidth)
+                        // If the two roofs occupy the same space, select tiles that best represent both roofs and delete the tile on the other
 
                         int heightOffsetTiles = yTO + (_tileHeight - other._tileHeight);  // yTO difference at base
 
@@ -386,9 +462,9 @@ namespace OpenTS2.Scenes.Lot.Roof
                         float heightDiff = (_height - other._height) + heightOffsetTiles * _slope;
 
                         int xFrom = Math.Max(0, xTO);
-                        int xTo = Math.Min(_tileWidth - 1, xTO + other._tileWidth);
+                        int xTo = Math.Min(_tileWidth - 1, xTO + other._tileWidth - 1);
                         int yFrom = Math.Max(0, -yTO);
-                        int yTo = Math.Min(_tileHeight - 1, other._tileHeight - yTO);
+                        int yTo = Math.Min(_tileHeight - 1, (other._tileHeight - 1) - yTO);
                         int xFromOther = Math.Max(0, -xTO);
                         int yFromOther = Math.Max(0, yTO);
 
@@ -405,14 +481,16 @@ namespace OpenTS2.Scenes.Lot.Roof
                                     ref RoofTile oTile = ref other._tiles[yO * other._tileWidth + xO];
 
                                     int prio1 = tile.OverlapPriority();
-                                    int prio2 = tile.OverlapPriority();
+                                    int prio2 = oTile.OverlapPriority();
 
                                     if (prio1 > prio2)
                                     {
+                                        tile.AddIntersectionsFrom(oTile);
                                         oTile.Delete();
                                     }
                                     else
                                     {
+                                        oTile.AddIntersectionsFrom(tile);
                                         tile.Delete();
                                     }
                                 }
@@ -427,8 +505,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                             {
                                 for (int x = xFrom, xO = xFromOther; x <= xTo; x++, xO++)
                                 {
-                                    if (x == 0 || x == _tileWidth - 1 || y == _tileHeight - 1 ||
-                                        xO == 0 || xO == other._tileWidth - 1 || yO == other._tileWidth - 1)
+                                    if (IsOverhang(x, y) || other.IsOverhang(xO, yO))
                                     {
                                         // Don't remove overhangs due to vertical overlap.
                                         // Only remove them if their donor tiles disappear.
@@ -440,100 +517,218 @@ namespace OpenTS2.Scenes.Lot.Roof
 
                                     if (thisHigher)
                                     {
-                                        oTile.Delete();
+                                        other.CutUsingTile(tile, xO, yO, 0);
+                                    }
+                                    else
+                                    {
+                                        CutUsingTile(oTile, x, y, 0);
+                                    }
+                                }
+                            }
+                        }
 
-                                        // Does this remove an overhang?
+                        break;
+                    }
+                case 1:
+                case 3:
+                    {
+                        if (dirDiff == 3)
+                        {
+                            // It's negative 90.
+                            // Flip this and other.
+                            (xTO, yTO) = (-yTO, xTO);
+                        }
 
-                                        if (xO == 1)
+                        RoofEdge left = (dirDiff == 3) ? other : this;
+                        RoofEdge right = (dirDiff == 3) ? this : other;
+
+                        xTO += 1; // Add left edge overflow of left
+                        yTO += 1; // Subtraft left edge of right
+
+                        // Other wall is 90 degrees from this one.
+                        // Left wall sees a diagonal intersection in form /
+                        // The right sees \
+
+                        int xFrom = Math.Max(0, xTO - right._tileHeight);
+                        int xTo = Math.Min(left._tileWidth - 1, xTO - 1);
+                        int yFrom = Math.Max(0, -yTO);
+                        int yTo = Math.Min(left._tileHeight - 1, (right._tileWidth - 1) - yTO);
+                        int xFromOther = Math.Max(0, yTO);
+                        int yFromOther = Math.Min(right._tileHeight - 1, xTO - 1);
+
+                        int heightNotches = Mathf.RoundToInt(left._height / left._slope);
+                        int oHeightNotches = Mathf.RoundToInt(right._height / right._slope);
+
+                        for (int y = yFrom, xO = xFromOther; y <= yTo; y++, xO++)
+                        {
+                            for (int x = xFrom, yO = yFromOther; x <= xTo; x++, yO--)
+                            {
+                                int tileHeight = heightNotches + (left._tileHeight - 1) - y;
+                                int tileHeightOther = oHeightNotches + (right._tileHeight - 1) - yO;
+
+                                ref RoofTile tile = ref left._tiles[y * left._tileWidth + x];
+                                ref RoofTile oTile = ref right._tiles[yO * right._tileWidth + xO];
+
+                                if (tileHeight < tileHeightOther)
+                                {
+                                    if (!right.IsOverhang(xO, yO))
+                                    {
+                                        left.CutUsingTile(oTile, x, y, 3);
+                                    }
+                                }
+                                else
+                                {
+                                    if (tileHeight == tileHeightOther)
+                                    {
+                                        // The fun one.
+
+                                        // Cut the top left of the left edge into the right edge.
+                                        RoofCut cutFromL = (tile.Cuts() & RoofCut.TopLeft) | RoofCut.BottomRight;
+                                        oTile.Cut(cutFromL, 1);
+
+                                        // Cut the top right of the right edge into the left edge.
+
+                                        RoofCut cutFromR = (oTile.Cuts() & RoofCut.TopRight) | RoofCut.BottomLeft;
+                                        tile.Cut(cutFromR, 3);
+
+                                        // Only add the intersection graphics to the left face if the right isn't fully cut out.
+                                        if ((oTile.Cuts() & RoofCut.TopRight) != RoofCut.TopRight)
                                         {
-                                            // Removes left overhang
-                                            other._tiles[yO * other._tileWidth].Delete();
+                                            tile.AddIntersection(RoofTileIntersection.Left);
 
-                                            if (yO == other._tileHeight - 2)
+                                            if (y > 0)
                                             {
-                                                // ... and bottom corner
-                                                other._tiles[(yO + 1) * other._tileWidth].Delete();
+                                                left._tiles[(y - 1) * left._tileWidth + x].AddIntersection(RoofTileIntersection.SmallLeft);
+
+                                                if (x < left._tileWidth - 1)
+                                                {
+                                                    left._tiles[(y - 1) * left._tileWidth + x + 1].AddIntersection(RoofTileIntersection.SmallRight);
+                                                }
+                                            }
+
+                                            if (x > 0 && y == yTo)
+                                            {
+                                                left._tiles[y * left._tileWidth + x - 1].AddIntersection(RoofTileIntersection.SmallLeft);
                                             }
                                         }
-                                        else if (xO == other._tileWidth - 2)
-                                        {
-                                            // Removes right overhang
-                                            other._tiles[yO * other._tileWidth + xO + 1].Delete();
 
-                                            if (yO == other._tileHeight - 2)
-                                            {
-                                                // ... and bottom corner
-                                                other._tiles[(yO + 1) * other._tileWidth + xO + 1].Delete();
-                                            }
-                                        }
-                                        else if (yO == other._tileHeight - 2)
+                                        // Only add the intersection graphics to the right face if the left isn't fully cut out.
+                                        if ((tile.Cuts() & RoofCut.TopLeft) != RoofCut.TopLeft)
                                         {
-                                            other._tiles[(yO + 1) * other._tileWidth].Delete();
+                                            oTile.AddIntersection(RoofTileIntersection.Right);
+
+                                            if (yO > 0)
+                                            {
+                                                right._tiles[(yO - 1) * right._tileWidth + xO].AddIntersection(RoofTileIntersection.SmallRight);
+
+                                                if (xO > 0)
+                                                {
+                                                    right._tiles[(yO - 1) * right._tileWidth + xO - 1].AddIntersection(RoofTileIntersection.SmallLeft);
+                                                }
+                                            }
+
+                                            if (xO < right._tileWidth - 1)
+                                            {
+                                                right._tiles[yO * right._tileWidth + xO + 1].AddIntersection(RoofTileIntersection.SmallRight);
+                                            }
                                         }
                                     }
                                     else
                                     {
-                                        tile.Delete();
-
-                                        // Does this remove an overhang?
-
-                                        if (x == 1)
+                                        if (!left.IsOverhang(x, y))
                                         {
-                                            // Removes left overhang
-                                            _tiles[y * _tileWidth].Delete();
-
-                                            if (y == _tileHeight - 2)
-                                            {
-                                                // ... and bottom corner
-                                                _tiles[(y + 1) * _tileWidth].Delete();
-                                            }
-                                        }
-                                        else if (x == _tileWidth - 2)
-                                        {
-                                            // Removes right overhang
-                                            _tiles[yO * _tileWidth + x + 1].Delete();
-
-                                            if (yO == _tileHeight - 2)
-                                            {
-                                                // ... and bottom corner
-                                                _tiles[(y + 1) * _tileWidth + x + 1].Delete();
-                                            }
-                                        }
-                                        else if (y == _tileHeight - 2)
-                                        {
-                                            _tiles[(y + 1) * _tileWidth].Delete();
+                                            right.CutUsingTile(tile, xO, yO, 1);
                                         }
                                     }
                                 }
                             }
                         }
 
-                        return true;
-                        //break;
-                    }
-                case 1:
-                    {
-                        // Other wall is 90 degrees from this one.
-                        // This wall sees a diagonal intersection in form /
-                        // The other sees \
                         break;
                     }
                 case 2:
                     {
                         // Roofs are opposite. Try find where the roofs intersect. Remove whichever one is lower, and on the intersection line add a cut.
-                        break;
-                    }
-                case 3:
-                    {
-                        // Other wall is -90 degrees from this one.
-                        // This wall sees a diagonal intersection in form \
-                        // The other sees /
+
+                        // Top lefts are flipped for each roof. Coordinates need to be flipped to be used on each other.
+
+                        // On offsets between inverted axis, we also need to count the extra tiles.
+                        xTO += 2; // Add this left and other right extent
+
+                        int xFrom = Math.Max(0, xTO - other._tileWidth);
+                        int xTo = Math.Min(_tileWidth - 1, xTO - 1);
+                        int yFrom = Math.Max(0, -yTO - other._tileHeight);
+                        int yTo = Math.Min(_tileHeight - 1, -yTO - 1);
+                        // TODO
+                        int xFromOther = Math.Min(other._tileWidth - 1, xTO - 1);
+                        int yFromOther = Math.Min(other._tileHeight - 1, -yTO - 1);
+
+                        int heightNotches = Mathf.RoundToInt(_height / _slope);
+                        int oHeightNotches = Mathf.RoundToInt(other._height / other._slope);
+
+                        for (int y = yFrom, yO = yFromOther; y <= yTo; y++, yO--)
+                        {
+                            int tileHeight = heightNotches + (_tileHeight - 1) - y;
+                            int tileHeightOther = oHeightNotches + (other._tileHeight - 1) - yO;
+
+                            for (int x = xFrom, xO = xFromOther; x <= xTo; x++, xO--)
+                            {
+                                ref RoofTile tile = ref _tiles[y * _tileWidth + x];
+                                ref RoofTile oTile = ref other._tiles[yO * other._tileWidth + xO];
+
+                                if (tileHeight < tileHeightOther)
+                                {
+                                    if (!other.IsOverhang(xO, yO))
+                                    {
+                                        CutUsingTile(oTile, x, y, dirDiff);
+                                    }
+
+                                    if (tileHeightOther == tileHeight + 1 && (tile.Cuts() & RoofCut.Top) == 0)
+                                    {
+                                        if (xO > 0)
+                                        {
+                                            other._tiles[yO * other._tileWidth + xO - 1].AddIntersection(RoofTileIntersection.SmallLeft);
+                                        }
+
+                                        oTile.AddIntersection(RoofTileIntersection.Bottom);
+
+                                        if (xO < other._tileWidth - 1)
+                                        {
+                                            other._tiles[yO * other._tileWidth + xO + 1].AddIntersection(RoofTileIntersection.SmallRight);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    if (!IsOverhang(x, y))
+                                    {
+                                        other.CutUsingTile(tile, xO, yO, dirDiff);
+                                    }
+
+                                    if (tileHeight == tileHeightOther + 1 && (oTile.Cuts() & RoofCut.Top) == 0)
+                                    {
+                                        if (x > 0)
+                                        {
+                                            _tiles[y * _tileWidth + x - 1].AddIntersection(RoofTileIntersection.SmallLeft);
+                                        }
+
+                                        tile.AddIntersection(RoofTileIntersection.Bottom);
+
+                                        if (x < _tileWidth - 1)
+                                        {
+                                            _tiles[y * _tileWidth + x + 1].AddIntersection(RoofTileIntersection.SmallRight);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
                         break;
                     }
 
             }
 
-            return false;
+            return true;
         }
 
         public void RemoveTilesUnder(IRoofType other)

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofEdge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdce2fa13f84af64685f80c079b378b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofGeometryCollection.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofGeometryCollection.cs
@@ -1,0 +1,43 @@
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public readonly struct RoofGeometryCollection
+    {
+        public readonly PatternMesh RoofTop;
+        public readonly PatternMesh RoofEdges;
+        public readonly PatternMesh RoofTrim;
+        public readonly PatternMesh RoofUnder;
+
+        public RoofGeometryCollection(
+            PatternMesh roofTop,
+            PatternMesh roofEdges,
+            PatternMesh roofTrim,
+            PatternMesh roofUnder)
+        {
+            RoofTop = roofTop;
+            RoofEdges = roofEdges;
+            RoofTrim = roofTrim;
+            RoofUnder = roofUnder;
+        }
+
+        public bool Valid()
+        {
+            return RoofTop != null;
+        }
+
+        public void Clear()
+        {
+            RoofTop.Component?.Clear();
+            RoofEdges.Component?.Clear();
+            RoofTrim.Component?.Clear();
+            RoofUnder.Component?.Clear();
+        }
+
+        public void Commit()
+        {
+            RoofTop.Component?.Commit();
+            RoofEdges.Component?.Commit();
+            RoofTrim.Component?.Commit();
+            RoofUnder.Component?.Commit();
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofGeometryCollection.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofGeometryCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a7a0ff456068984b8b8fba4c0d969fe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
@@ -1,0 +1,170 @@
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public enum RoofTileBase : byte
+    {
+        Normal = 0,
+        LeftEdge = 1,
+        SmallLeftEdge = 2,
+        LeftToTop = 3,
+        Top = 4,
+        TopToRight = 5,
+        SmallRightEdge = 6,
+        RightEdge = 7,
+        
+        Empty = 8
+    }
+
+    public enum RoofTileIntersection : byte
+    {
+        None = 0,
+        SmallLeft = 1,
+        SmallRight = 2,
+        Bottom = 3,
+        Left = 4,
+        Right = 5
+    }
+
+    public struct AtlasIndex
+    {
+        public int Index;
+        public bool Flip;
+
+        public AtlasIndex(int index, bool flip = false)
+        {
+            Index = index;
+            Flip = flip;
+        }
+    }
+
+    public struct RoofTile
+    {
+        public static AtlasIndex[][] BAndIToAtlasIndex =
+        {
+            // Normal = 0,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(0), // None = 0,
+                new AtlasIndex(15, true), // SmallLeft = 1,
+                new AtlasIndex(15), // SmallRight = 2,
+                new AtlasIndex(13), // Bottom = 3,
+                new AtlasIndex(2), // Left = 4,
+                new AtlasIndex(16), // Right = 5
+            },
+
+            // LeftEdge = 1,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(20), // None = 0,
+                new AtlasIndex(-1), // SmallLeft = 1,
+                new AtlasIndex(-1), // SmallRight = 2,
+                new AtlasIndex(12), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4,
+                new AtlasIndex(-1), // Right = 5
+            },
+
+            // SmallLeftEdge = 2,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(21), // None = 0,
+                new AtlasIndex(6), // SmallLeft = 1,
+                new AtlasIndex(-1), // SmallRight = 2,
+                new AtlasIndex(17), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4,
+                new AtlasIndex(10), // Right = 5
+            },
+
+            // LeftToTop = 3,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(8), // None = 0,
+                new AtlasIndex(7), // SmallLeft = 1,
+                new AtlasIndex(-1), // SmallRight = 2,
+                new AtlasIndex(3), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4, // Flip 11 substitute?
+                new AtlasIndex(-1), // Right = 5 // 11 substitute?
+            },
+
+            // Top = 4,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(22), // None = 0,
+                new AtlasIndex(18, true), // SmallLeft = 1,
+                new AtlasIndex(18), // SmallRight = 2,
+                new AtlasIndex(23), // Bottom = 3,
+                new AtlasIndex(11, true), // Left = 4,
+                new AtlasIndex(11), // Right = 5
+            },
+
+            // TopToRight = 5,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(8, true), // None = 0,
+                new AtlasIndex(-1), // SmallLeft = 1,
+                new AtlasIndex(7, true), // SmallRight = 2,
+                new AtlasIndex(3, true), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4, // Flip 11 substitute?
+                new AtlasIndex(-1), // Right = 5 // 11 substitute?
+            },
+
+            // SmallRightEdge = 6,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(14), // None = 0,
+                new AtlasIndex(-1), // SmallLeft = 1,
+                new AtlasIndex(6, true), // SmallRight = 2,
+                new AtlasIndex(17, true), // Bottom = 3,
+                new AtlasIndex(10, true), // Left = 4,
+                new AtlasIndex(-1), // Right = 5
+            },
+
+            // RightEdge = 7,
+            new AtlasIndex[]
+            {
+                new AtlasIndex(24), // None = 0,
+                new AtlasIndex(-1), // SmallLeft = 1,
+                new AtlasIndex(-1), // SmallRight = 2,
+                new AtlasIndex(12, true), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4,
+                new AtlasIndex(-1), // Right = 5
+            },
+
+            // Empty = 8
+            new AtlasIndex[]
+            {
+                new AtlasIndex(-1), // None = 0,
+                new AtlasIndex(-1), // SmallLeft = 1,
+                new AtlasIndex(-1), // SmallRight = 2,
+                new AtlasIndex(-1), // Bottom = 3,
+                new AtlasIndex(-1), // Left = 4,
+                new AtlasIndex(-1), // Right = 5
+            }
+        };
+
+        private RoofTileBase _base;
+        private RoofTileIntersection _intersection;
+
+        public RoofTile(RoofTileBase baseTile)
+        {
+            _base = baseTile;
+            _intersection = RoofTileIntersection.None;
+        }
+
+        public void AddIntersection(RoofTileIntersection incoming)
+        {
+            if (incoming > _intersection && BAndIToAtlasIndex[(int)_base][(int)incoming].Index != -1)
+            {
+                _intersection = incoming;
+            }
+        }
+
+        public void Delete()
+        {
+            _base = RoofTileBase.Empty;
+        }
+
+        public AtlasIndex GetAtlasIndex()
+        {
+            return BAndIToAtlasIndex[(int)_base][(int)_intersection];
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
@@ -100,8 +100,8 @@ namespace OpenTS2.Scenes.Lot.Roof
                 new AtlasIndex(7), // SmallLeft = 1,
                 new AtlasIndex(-1), // SmallRight = 2,
                 new AtlasIndex(3), // Bottom = 3,
-                new AtlasIndex(-1), // Left = 4, // Flip 11 substitute?
-                new AtlasIndex(-1), // Right = 5 // 11 substitute?
+                new AtlasIndex(11, true), // Left = 4, // Flip 11 substitute
+                new AtlasIndex(11), // Right = 5 // 11 substitute
             },
 
             // Top = 4,
@@ -122,8 +122,8 @@ namespace OpenTS2.Scenes.Lot.Roof
                 new AtlasIndex(-1), // SmallLeft = 1,
                 new AtlasIndex(7, true), // SmallRight = 2,
                 new AtlasIndex(3, true), // Bottom = 3,
-                new AtlasIndex(-1), // Left = 4, // Flip 11 substitute?
-                new AtlasIndex(-1), // Right = 5 // 11 substitute?
+                new AtlasIndex(11, true), // Left = 4, // Flip 11 substitute
+                new AtlasIndex(11), // Right = 5 // 11 substitute
             },
 
             // SmallRightEdge = 6,
@@ -268,6 +268,9 @@ namespace OpenTS2.Scenes.Lot.Roof
                     return 3;
                 case RoofTileBase.Top:
                     return 2;
+                case RoofTileBase.LeftToTop:
+                case RoofTileBase.TopToRight:
+                    return 1;
                 default:
                     return 0;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
@@ -43,7 +43,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             // Normal = 0,
             new AtlasIndex[]
             {
-                new AtlasIndex(0), // None = 0,
+                new AtlasIndex(9), // None = 0,
                 new AtlasIndex(15, true), // SmallLeft = 1,
                 new AtlasIndex(15), // SmallRight = 2,
                 new AtlasIndex(13), // Bottom = 3,
@@ -120,7 +120,7 @@ namespace OpenTS2.Scenes.Lot.Roof
             // RightEdge = 7,
             new AtlasIndex[]
             {
-                new AtlasIndex(24), // None = 0,
+                new AtlasIndex(1), // None = 0,
                 new AtlasIndex(-1), // SmallLeft = 1,
                 new AtlasIndex(-1), // SmallRight = 2,
                 new AtlasIndex(12, true), // Bottom = 3,
@@ -165,6 +165,33 @@ namespace OpenTS2.Scenes.Lot.Roof
         public AtlasIndex GetAtlasIndex()
         {
             return BAndIToAtlasIndex[(int)_base][(int)_intersection];
+        }
+
+        public int CutDir()
+        {
+            switch (_base)
+            {
+                case RoofTileBase.LeftEdge:
+                    return -1;
+                case RoofTileBase.RightEdge:
+                    return 1;
+                default:
+                    return 0;
+            }
+        }
+
+        public int OverlapPriority()
+        {
+            switch (_base)
+            {
+                case RoofTileBase.Normal:
+                    return 2;
+                case RoofTileBase.SmallLeftEdge:
+                case RoofTileBase.SmallRightEdge:
+                    return 1;
+                default:
+                    return 0;
+            }
         }
     }
 }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs
@@ -222,6 +222,8 @@ namespace OpenTS2.Scenes.Lot.Roof
                     return RoofCut.TopLeft;
                 case RoofTileBase.RightEdge:
                     return RoofCut.TopRight;
+                case RoofTileBase.Empty:
+                    return RoofCut.All;
                 default:
                     return 0;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/RoofTile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aa936cd82396be4ca6cba2edc34131f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
@@ -1,0 +1,51 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class ShedGableRoof : AbstractSimpleRoof
+    {
+        public ShedGableRoof(RoofEntry entry, float height) : base(entry, height)
+        {
+            int dir = DetermineDirectionCardinal(entry);
+
+            Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
+            Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
+            Vector2 br = new Vector2(tr.x, bl.y);
+            Vector2 tl = new Vector2(bl.x, tr.y);
+
+            // "Towards" means that the wall edge is facing that direction.
+
+            float slope = entry.RoofAngle;
+
+            switch (dir)
+            {
+                case 0: // Towards positive x
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, tl, bl, br, tr, true, true),
+                    };
+                    break;
+                case 1: // Towards positive y
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, bl, br, tr, tl, true, true),
+                    };
+                    break;
+                case 2: // Towards negative x
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, br, tr, tl, bl, true, true),
+                    };
+                    break;
+                case 3: // Towards negative y
+                    Edges = new RoofEdge[]
+                    {
+                        new RoofEdge(height, slope, tr, tl, bl, br, true, true),
+                    };
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
@@ -24,25 +24,25 @@ namespace OpenTS2.Scenes.Lot.Roof
                 case 0: // Towards positive x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tl, bl, br, tr, true, true),
+                        new RoofEdge(height, slope, tl, bl, br, tr, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
                     };
                     break;
                 case 1: // Towards positive y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, bl, br, tr, tl, true, true),
+                        new RoofEdge(height, slope, bl, br, tr, tl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
                     };
                     break;
                 case 2: // Towards negative x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, br, tr, tl, bl, true, true),
+                        new RoofEdge(height, slope, br, tr, tl, bl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
                     };
                     break;
                 case 3: // Towards negative y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tr, tl, bl, br, true, true),
+                        new RoofEdge(height, slope, tr, tl, bl, br, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
                     };
                     break;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs
@@ -6,7 +6,7 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class ShedGableRoof : AbstractSimpleRoof
     {
-        public ShedGableRoof(RoofEntry entry, float height) : base(entry, height)
+        public ShedGableRoof(RoofEntry entry, float height, bool pagoda = false) : base(entry, height)
         {
             int dir = DetermineDirectionCardinal(entry);
 
@@ -24,25 +24,25 @@ namespace OpenTS2.Scenes.Lot.Roof
                 case 0: // Towards positive x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tl, bl, br, tr, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                        new RoofEdge(height, slope, tl, bl, br, tr, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
                     };
                     break;
                 case 1: // Towards positive y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, bl, br, tr, tl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                        new RoofEdge(height, slope, bl, br, tr, tl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
                     };
                     break;
                 case 2: // Towards negative x
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, br, tr, tl, bl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                        new RoofEdge(height, slope, br, tr, tl, bl, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
                     };
                     break;
                 case 3: // Towards negative y
                     Edges = new RoofEdge[]
                     {
-                        new RoofEdge(height, slope, tr, tl, bl, br, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat),
+                        new RoofEdge(height, slope, tr, tl, bl, br, RoofEdgeEnd.Flat, RoofEdgeEnd.Flat, pagoda: pagoda),
                     };
                     break;
             }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedGableRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2944bb624b79bf841bcbe740b4758e5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
@@ -1,0 +1,60 @@
+using OpenTS2.Content.DBPF;
+using System;
+using UnityEngine;
+
+namespace OpenTS2.Scenes.Lot.Roof
+{
+    public class ShedHipRoof : AbstractSimpleRoof
+    {
+        private Vector2 RotateVector(Vector2 vec, int dir)
+        {
+            switch (dir)
+            {
+                case 1:
+                    return new Vector2(-vec.y, vec.x);
+                case 2:
+                    return new Vector2(-vec.x, -vec.y);
+                case 3:
+                    return new Vector2(vec.x, -vec.y);
+            }
+
+            return vec;
+        }
+
+        public ShedHipRoof(RoofEntry entry, float height) : base(entry, height)
+        {
+            int dir = DetermineDirectionCardinal(entry);
+
+            Vector2 bl = new Vector2(Math.Min(entry.XFrom, entry.XTo), Math.Min(entry.YFrom, entry.YTo));
+            Vector2 tr = new Vector2(Math.Max(entry.XFrom, entry.XTo), Math.Max(entry.YFrom, entry.YTo));
+            Vector2 br = new Vector2(tr.x, bl.y);
+            Vector2 tl = new Vector2(bl.x, tr.y);
+
+            Vector2[] corners = new Vector2[]
+            {
+                tl, bl, br, tr
+            };
+
+            bool flatInX = ((dir % 2) == 0);
+
+            float minDim = flatInX ?
+                Math.Min(tr.x - bl.x, (tr.y - bl.y) / 2) : // In x direction
+                Math.Min((tr.x - bl.x) / 2, tr.y - bl.y);  // In y direction
+
+            Vector2 towardsDirection = RotateVector(new Vector2(minDim, 0), dir);
+            Vector2 towardsTop = RotateVector(new Vector2(0, minDim), dir);
+
+            Vector2 c1 = corners[dir];
+            Vector2 c2 = corners[(dir + 1) % 4];
+
+            float slope = entry.RoofAngle;
+
+            Edges = new RoofEdge[]
+            {
+                new RoofEdge(height, slope, corners[(dir + 3) % 4], c1, c2 - towardsTop, c1 - towardsTop, true, false),
+                new RoofEdge(height, slope, c1, c2, c2 + towardsDirection, c1 + towardsDirection),
+                new RoofEdge(height, slope, c2, corners[(dir + 2) % 4], c2 + towardsTop, c1 + towardsTop, false, true),
+            };
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
@@ -6,21 +6,6 @@ namespace OpenTS2.Scenes.Lot.Roof
 {
     public class ShedHipRoof : AbstractSimpleRoof
     {
-        private Vector2 RotateVector(Vector2 vec, int dir)
-        {
-            switch (dir)
-            {
-                case 1:
-                    return new Vector2(-vec.y, vec.x);
-                case 2:
-                    return new Vector2(-vec.x, -vec.y);
-                case 3:
-                    return new Vector2(vec.y, -vec.x);
-            }
-
-            return vec;
-        }
-
         public ShedHipRoof(RoofEntry entry, float height) : base(entry, height)
         {
             int dir = DetermineDirectionCardinal(entry);

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
@@ -46,14 +46,16 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             Vector2 c1 = corners[dir];
             Vector2 c2 = corners[(dir + 1) % 4];
+            Vector2 c3 = corners[(dir + 2) % 4];
+            Vector2 c4 = corners[(dir + 3) % 4];
 
             float slope = entry.RoofAngle;
 
             Edges = new RoofEdge[]
             {
-                new RoofEdge(height, slope, corners[(dir + 3) % 4], c1, c2 - towardsTop, c1 - towardsTop, true, false),
+                new RoofEdge(height, slope, c4, c1, c1 - towardsTop, c4 - towardsTop, true, false),
                 new RoofEdge(height, slope, c1, c2, c2 + towardsDirection, c1 + towardsDirection),
-                new RoofEdge(height, slope, c2, corners[(dir + 2) % 4], c2 + towardsTop, c1 + towardsTop, false, true),
+                new RoofEdge(height, slope, c2, c3, c3 + towardsTop, c2 + towardsTop, false, true),
             };
         }
     }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
@@ -53,9 +53,9 @@ namespace OpenTS2.Scenes.Lot.Roof
 
             Edges = new RoofEdge[]
             {
-                new RoofEdge(height, slope, c4, c1, c1 - towardsTop, c4 - towardsTop, true, false),
+                new RoofEdge(height, slope, c4, c1, c1 - towardsTop, c4 - towardsTop, RoofEdgeEnd.FlatShort, RoofEdgeEnd.Normal),
                 new RoofEdge(height, slope, c1, c2, c2 + towardsDirection, c1 + towardsDirection),
-                new RoofEdge(height, slope, c2, c3, c3 + towardsTop, c2 + towardsTop, false, true),
+                new RoofEdge(height, slope, c2, c3, c3 + towardsTop, c2 + towardsTop, RoofEdgeEnd.Normal, RoofEdgeEnd.FlatShort),
             };
         }
     }

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs
@@ -15,7 +15,7 @@ namespace OpenTS2.Scenes.Lot.Roof
                 case 2:
                     return new Vector2(-vec.x, -vec.y);
                 case 3:
-                    return new Vector2(vec.x, -vec.y);
+                    return new Vector2(vec.y, -vec.x);
             }
 
             return vec;

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/Roof/ShedHipRoof.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c78edd56e74db8747ad14775630c2e6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/State.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/State.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c5246f0de226384a9ef71dd679debd5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/State/WorldState.cs
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/State/WorldState.cs
@@ -1,0 +1,22 @@
+namespace OpenTS2.Scenes.Lot.State
+{
+    public enum WallsMode
+    {
+        Down,
+        Cutaway,
+        Up,
+        Roof
+    }
+
+    public readonly struct WorldState
+    {
+        public readonly int Level;
+        public readonly WallsMode Walls;
+
+        public WorldState(int level, WallsMode walls)
+        {
+            Level = level;
+            Walls = walls;
+        }
+    }
+}

--- a/Assets/Scripts/OpenTS2/Scenes/Lot/State/WorldState.cs.meta
+++ b/Assets/Scripts/OpenTS2/Scenes/Lot/State/WorldState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7918308d11f816b449637457a3bd5465
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Lot.meta
+++ b/Assets/Shaders/Lot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 74ccc83396da4754292d1dd58422222e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Lot/Terrain.shader
+++ b/Assets/Shaders/Lot/Terrain.shader
@@ -1,0 +1,91 @@
+Shader "OpenTS2/Terrain"
+{
+    Properties
+    {
+        _BaseTexture ("Texture", 2D) = "white" {}
+        _BlendBitmap("Blend Bitmap", 2D) = "black" {}
+        _BlendTextures("Blend Textures", 2DArray) = "" {}
+        _BlendMasks("Blend Masks", 2DArray) = "" {}
+
+        _InvLotSize("Inv Lot Size", Vector) = (0, 0, 0, 0)
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+
+        CGPROGRAM
+        #pragma surface surf Lambert fullforwardshadows
+        #pragma require 2darray
+
+        #include "UnityCG.cginc"
+
+        struct Input {
+            float2 uv_BaseTexture;
+        };
+
+        sampler2D _BaseTexture;
+        sampler2D _BlendBitmap;
+        UNITY_DECLARE_TEX2DARRAY(_BlendTextures);
+        UNITY_DECLARE_TEX2DARRAY(_BlendMasks);
+
+        float4 _BlendBitmap_TexelSize;
+        float4 _BlendTextures_TexelSize;
+        float2 _InvLotSize;
+
+        uint4 gather(sampler2D samp, fixed2 uv, float4 texSize) {
+            // A shame that this isn't natively supported...
+            float2 texelLocation = frac(uv) * texSize.zw;
+
+            float2 offset = round(frac(texelLocation)) * float2(2, 2) - float2(1, 1);
+            float2 texelCenter = floor(texelLocation) + float2(0.5, 0.5);
+
+            uint4 result = uint4(
+                asuint(tex2D(samp, texelCenter * texSize.xy).x),
+                asuint(tex2D(samp, (texelCenter + int2(offset.x, 0)) * texSize.xy).x),
+                asuint(tex2D(samp, (texelCenter + int2(0, offset.y)) * texSize.xy).x),
+                asuint(tex2D(samp, (texelCenter + offset) * texSize.xy).x)
+            );
+
+            return result;
+        }
+
+        void surf(Input i, inout SurfaceOutput o)
+        {
+            // Sample base texture
+            fixed2 texUV = i.uv_BaseTexture / 4.0;
+            fixed4 col = tex2D(_BaseTexture, texUV);
+
+            // Sample the bitmap to check which blend textures need to be sampled.
+            fixed2 maskUV = (i.uv_BaseTexture - fixed2(3.0/16.0, 3.0/16.0)) * _InvLotSize.xy;
+            uint4 textureBits = gather(_BlendBitmap, maskUV, _BlendBitmap_TexelSize);
+
+            // Combine the gather values
+            uint mask = textureBits.x | textureBits.y | textureBits.z | textureBits.w;
+
+            fixed2 uvScaled = texUV * _BlendTextures_TexelSize.zw;
+
+            float2 dxUv = ddx(uvScaled);
+            float2 dyUv = ddy(uvScaled);
+            float maxDerivative = max(dot(dxUv, dxUv), dot(dyUv, dyUv));
+            float level = 0.5 * log2(maxDerivative);
+
+            // Only blend in the layers that are in the mask.
+            [loop]
+            while (mask != 0)
+            {
+                int bit = firstbitlow(mask);
+
+                fixed4 blendCol = UNITY_SAMPLE_TEX2DARRAY_LOD(_BlendTextures, float3(texUV, float(bit)), level);
+                float blendMask = UNITY_SAMPLE_TEX2DARRAY_LOD(_BlendMasks, float3(maskUV, float(bit)), 0).x;
+
+                col = lerp(col, blendCol, blendMask);
+
+                mask &= ~(1 << bit);
+            }
+
+            o.Albedo = col;
+        }
+        ENDCG
+    }
+    Fallback "Diffuse"
+}

--- a/Assets/Shaders/Lot/Terrain.shader.meta
+++ b/Assets/Shaders/Lot/Terrain.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 99d4c2193a8ae8c4b9a141c07ac72fdf
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/StandardMaterial/AlphaBlended.shader
+++ b/Assets/Shaders/StandardMaterial/AlphaBlended.shader
@@ -7,6 +7,7 @@ Shader "OpenTS2/StandardMaterial/AlphaBlended"
         _AlphaMultiplier("Alpha Multiplier", Range(0.0, 1.0)) = 1.0
         _BumpMap("Bump Map", 2D) = "white" {}
         _DiffuseCoefficient("Diffuse color coefficient", Color) = (1, 1, 1, 1)
+        _UVScale("UV scale", Vector) = (1, 1, 0, 0)
 
         _SeaLevel("Sea Level", float) = -100.0
     }

--- a/Assets/Shaders/StandardMaterial/AlphaBlended.shader
+++ b/Assets/Shaders/StandardMaterial/AlphaBlended.shader
@@ -14,7 +14,7 @@ Shader "OpenTS2/StandardMaterial/AlphaBlended"
     SubShader
     {
         ZWrite Off
-        Tags { "RenderType"="Transparent" "Queue"="Transparent" }
+        Tags { "RenderType"="Transparent" "Queue"="Transparent" "ForceNoShadowCasting"="True" }
 
         CGPROGRAM
         #pragma surface surf Lambert fullforwardshadows alpha:blend

--- a/Assets/Shaders/StandardMaterial/AlphaCutOut.shader
+++ b/Assets/Shaders/StandardMaterial/AlphaCutOut.shader
@@ -7,6 +7,7 @@ Shader "OpenTS2/StandardMaterial/AlphaCutOut"
         _AlphaMultiplier ("Alpha Multiplier", Range(0.0, 1.0)) = 1.0
         _BumpMap("Bump Map", 2D) = "white" {}
         _DiffuseCoefficient("Diffuse color coefficient", Color) = (1, 1, 1, 1)
+        _UVScale("UV scale", Vector) = (1, 1, 0, 0)
 
         _SeaLevel("Sea Level", float) = -100.0
 
@@ -22,7 +23,7 @@ Shader "OpenTS2/StandardMaterial/AlphaCutOut"
                 Pass Replace
             }
         CGPROGRAM
-        #pragma surface surf Lambert fullforwardshadows alphatest:_AlphaCutOff
+        #pragma surface surf Lambert addshadow fullforwardshadows alphatest:_AlphaCutOff
 
         #include "Assets/Shaders/StandardMaterial/shader_body.cginc"
 

--- a/Assets/Shaders/StandardMaterial/Opaque.shader
+++ b/Assets/Shaders/StandardMaterial/Opaque.shader
@@ -7,6 +7,7 @@ Shader "OpenTS2/StandardMaterial/Opaque"
         _AlphaMultiplier ("Alpha Multiplier", Range(0.0, 1.0)) = 1.0
         _BumpMap("Bump Map", 2D) = "white" {}
         _DiffuseCoefficient("Diffuse color coefficient", Color) = (1, 1, 1, 1)
+        _UVScale("UV scale", Vector) = (1, 1, 0, 0)
 
         _SeaLevel("Sea Level", float) = -100.0
     }

--- a/Assets/Shaders/StandardMaterial/Wall.shader
+++ b/Assets/Shaders/StandardMaterial/Wall.shader
@@ -38,15 +38,6 @@ Shader "OpenTS2/StandardMaterial/Wall"
         float4 _DiffuseCoefficient;
         float4 _InvLotSize;
 
-        struct VertInput
-        {
-            float2 texcoord_MainTex : TEXCOORD1;
-            float2 texcoord_WallsDownTex : TEXCOORD2;
-            float4 vertex;
-            float4 tangent;
-            float3 normal;
-        };
-
         struct Input
         {
             float2 uv_MainTex;

--- a/Assets/Shaders/StandardMaterial/Wall.shader
+++ b/Assets/Shaders/StandardMaterial/Wall.shader
@@ -1,0 +1,111 @@
+Shader "OpenTS2/StandardMaterial/Wall"
+{
+    Properties
+    {
+        // Parameters common to all StandardMaterial shaders.
+        [NoScaleOffset] _MainTex ("Texture", 2D) = "white" {}
+        [NoScaleOffset] _WallsDownTex ("Walls Down Texture", 2D) = "black" {}
+        [NoScaleOffset] _MaskTex ("Mask Texture", 2D) = "white" {}
+        _AlphaMultiplier ("Alpha Multiplier", Range(0.0, 1.0)) = 1.0
+        _BumpMap("Bump Map", 2D) = "white" {}
+        _DiffuseCoefficient("Diffuse color coefficient", Color) = (1, 1, 1, 1)
+        _InvLotSize("Inverse lot size", Vector) = (1, 1, 0, 0)
+
+        // Parameters specific to AlphaCutOut.
+        _AlphaCutOff ("AlphaCutOff", Float) = 1.0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="AlphaTest" "Queue"="AlphaTest" }
+        Stencil {
+                Ref 0
+                Comp Always
+                Pass Replace
+            }
+        CGPROGRAM
+        #pragma surface surf Lambert addshadow fullforwardshadows alphatest:_AlphaCutOff vertex:vert
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+
+        sampler2D _MainTex;
+        sampler2D _MaskTex;
+        sampler2D _WallsDownTex;
+        sampler2D _BumpMap;
+        uniform float4 _BumpMap_TexelSize;
+        float _AlphaMultiplier;
+
+        float4 _DiffuseCoefficient;
+        float4 _InvLotSize;
+
+        struct VertInput
+        {
+            float2 texcoord_MainTex : TEXCOORD1;
+            float2 texcoord_WallsDownTex : TEXCOORD2;
+            float4 vertex;
+            float4 tangent;
+            float3 normal;
+        };
+
+        struct Input
+        {
+            float2 uv_MainTex;
+            float3 vertex;
+        };
+
+        float3 normalFromBumpMap(float2 coords, float intensity)
+        {
+            float3 graynorm = float3(0, 0, 1);
+            float heightSampleCenter = tex2D(_BumpMap, coords).r * intensity;
+            float heightSampleRight = tex2D(_BumpMap, coords + float2(_BumpMap_TexelSize.x, 0)).r * intensity;
+            float heightSampleUp = tex2D(_BumpMap, coords + float2(0, _BumpMap_TexelSize.y)).r * intensity;
+            float sampleDeltaRight = heightSampleRight - heightSampleCenter;
+            float sampleDeltaUp = heightSampleUp - heightSampleCenter;
+            graynorm = cross(
+                float3(1, 0, sampleDeltaRight),
+                float3(0, 1, sampleDeltaUp));
+
+            float3 bumpNormal = normalize(graynorm);
+            return bumpNormal;
+        }
+
+        void cutWallsDown (inout appdata_full v) {
+            fixed2 uv = fixed2(v.vertex.x, v.vertex.z) * _InvLotSize.xy;
+            fixed wallDown = tex2Dlod(_WallsDownTex, fixed4(uv, 0.0, 0.0)).r;
+            fixed offset = wallDown * v.texcoord1.y;
+
+            v.vertex.y -= offset;
+            v.texcoord.y += offset / 3.0;
+        }
+
+        void vert (inout appdata_full v) {
+            #if !defined(UNITY_PASS_SHADOWCASTER)
+            cutWallsDown(v);
+            #else
+            // A bit of a hack, since the same shader is used for depth prepass (forward rendering).
+            // In the shadowmap shader, this should be assigned.
+            if (unity_LightShadowBias.y == 0.0) {
+                cutWallsDown(v);
+            }
+            #endif
+        }
+
+        void surf (Input IN, inout SurfaceOutput o)
+        {
+            fixed4 c = _DiffuseCoefficient;
+            float2 uv = IN.uv_MainTex;
+            c *= tex2D (_MainTex, uv);
+            c.a *= tex2D (_MaskTex, uv).r;
+            c.a *= _AlphaMultiplier;
+
+            float3 bumpNormal = normalFromBumpMap(uv, 5);
+
+            o.Normal = bumpNormal;
+            o.Albedo = c.rgb;
+            o.Alpha = c.a;
+        }
+
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/Assets/Shaders/StandardMaterial/Wall.shader.meta
+++ b/Assets/Shaders/StandardMaterial/Wall.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 75e0683a765caef42b3b3feffe1eee77
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/StandardMaterial/shader_body.cginc
+++ b/Assets/Shaders/StandardMaterial/shader_body.cginc
@@ -8,7 +8,7 @@ float _SeaLevel;
 float _AlphaMultiplier;
 
 float4 _DiffuseCoefficient;
-
+float4 _UVScale;
 
 struct Input
 {
@@ -35,7 +35,8 @@ float3 normalFromBumpMap(float2 coords, float intensity)
 void surf (Input IN, inout SurfaceOutput o)
 {
     fixed4 c = _DiffuseCoefficient;
-    c *= tex2D (_MainTex, IN.uv_MainTex);
+    float2 uv = IN.uv_MainTex * _UVScale.xy;
+    c *= tex2D (_MainTex, uv);
 
     c.a *= _AlphaMultiplier;
 
@@ -44,7 +45,7 @@ void surf (Input IN, inout SurfaceOutput o)
     fixed4 seaColor = fixed4(0, 0, 0, 1);
     c.rgb = lerp(c, seaColor, seaAmount).rgb;
 
-    float3 bumpNormal = normalFromBumpMap(IN.uv_MainTex, 5);
+    float3 bumpNormal = normalFromBumpMap(uv, 5);
 
     o.Normal = bumpNormal;
     o.Albedo = c.rgb;


### PR DESCRIPTION
![image](https://github.com/LazyDuchess/OpenTS2/assets/6294155/846e656a-87d5-40f9-b72b-6099a1cc5bd6)

Adds support for:
- Terrain
  - Up to 32 blend textures, one draw. Creates a bitmask to select which blend textures to use.
  - Textures are placed on a texture array, but they can be different sizes... so they have to be blit into an uncompressed one.
- Floors
  - Diagonals, edges fully supported
- Walls
  - Intersections
  - Foundation/Decking
  - Fences (with slopes)
  - Roof-walls
  - Half-walls
  - Groundwork for object cutouts is in place, something just needs to apply them...
- Roofs
  - Fancy intersections which match the base game wherever possible.
  - Normal, Diagonal, Pagoda, Diagonal pagoda...
- Water
- Controls for quickly switching lot in Play mode (use Controller in editor)
- All components have been split into floors so they can be shown/hidden by user controls, and partially updated.
- View level and walls mode configurable in Play mode (use Controller in editor)

TODO in future:
- Ceilings
- Pools
- A lot more 3ARY resources (rooms, reserved tiles, ceilings, etc)
- Rooms (and cutaways)
- Special roofs (octogonal, cone, sphere, greenhouse)
- Wall intersections should have different tracking for wall/roofwall/half wall
- Anything to do with editing
  - "Dirty" tracking for floors, regenerating modified floors when a change is made
  - Wall runtime structure with fast lookup and editing tools, useful for simulator placement rules too
- Bump maps on terrain textures
- Improve materials stuff
- Improve roof cuts when not tile-compatible.